### PR TITLE
JKS as argument

### DIFF
--- a/mockserver-client-java/pom.xml
+++ b/mockserver-client-java/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>3.9.2-SNAPSHOT</version>
+        <version>3.9.3-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-client-javascript/pom.xml
+++ b/mockserver-client-javascript/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>3.9.2-SNAPSHOT</version>
+        <version>3.9.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mockserver-client-ruby/pom.xml
+++ b/mockserver-client-ruby/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>3.9.2-SNAPSHOT</version>
+        <version>3.9.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mockserver-core/pom.xml
+++ b/mockserver-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>3.9.2-SNAPSHOT</version>
+        <version>3.9.3-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-core/src/main/java/org/mockserver/socket/SSLFactory.java
+++ b/mockserver-core/src/main/java/org/mockserver/socket/SSLFactory.java
@@ -21,7 +21,7 @@ public class SSLFactory {
 
     public static final String KEY_STORE_CERT_ALIAS = "certAlias";
     public static final String KEY_STORE_CA_ALIAS = "caAlias";
-    public static final String KEY_STORE_PASSWORD = "changeit";
+    public static String KEY_STORE_PASSWORD = "changeit";
     public static final String KEY_STORE_FILENAME = "keystore.jks";
     private static final SSLFactory sslFactory = new SSLFactory();
     private static final Logger logger = LoggerFactory.getLogger(SSLFactory.class);

--- a/mockserver-core/src/main/java/org/mockserver/socket/SSLFactory.java
+++ b/mockserver-core/src/main/java/org/mockserver/socket/SSLFactory.java
@@ -21,7 +21,7 @@ public class SSLFactory {
 
     public static final String KEY_STORE_CERT_ALIAS = "certAlias";
     public static final String KEY_STORE_CA_ALIAS = "caAlias";
-    public static String KEY_STORE_PASSWORD = "changeit";
+    public static String keyStorePassword = "changeit";
     public static final String KEY_STORE_FILENAME = "keystore.jks";
     private static final SSLFactory sslFactory = new SSLFactory();
     private static final Logger logger = LoggerFactory.getLogger(SSLFactory.class);
@@ -56,7 +56,7 @@ public class SSLFactory {
         try {
             // key manager
             KeyManagerFactory keyManagerFactory = getKeyManagerFactoryInstance(KeyManagerFactory.getDefaultAlgorithm());
-            keyManagerFactory.init(buildKeyStore(), KEY_STORE_PASSWORD.toCharArray());
+            keyManagerFactory.init(buildKeyStore(), keyStorePassword.toCharArray());
 
             // ssl context
             SSLContext sslContext = getSSLContextInstance("TLS");
@@ -106,7 +106,7 @@ public class SSLFactory {
             keystore = new KeyStoreFactory().generateCertificate(
                     KEY_STORE_CERT_ALIAS,
                     KEY_STORE_CA_ALIAS,
-                    KEY_STORE_PASSWORD.toCharArray(),
+                    keyStorePassword.toCharArray(),
                     "localhost", null, null
             );
         } catch (Exception e) {
@@ -121,7 +121,7 @@ public class SSLFactory {
                 fileInputStream = new FileInputStream(KEY_STORE_FILENAME);
                 logger.trace("Loading key store from file [" + keyStoreFile + "]");
                 keystore = KeyStore.getInstance(KeyStore.getDefaultType());
-                keystore.load(fileInputStream, KEY_STORE_PASSWORD.toCharArray());
+                keystore.load(fileInputStream, keyStorePassword.toCharArray());
             } finally {
                 if (fileInputStream != null) {
                     fileInputStream.close();
@@ -135,7 +135,7 @@ public class SSLFactory {
     private void saveKeyStore() {
         try {
             ByteArrayOutputStream bout = new ByteArrayOutputStream();
-            keystore.store(bout, KEY_STORE_PASSWORD.toCharArray());
+            keystore.store(bout, keyStorePassword.toCharArray());
             File keyStoreFile = new File(KEY_STORE_FILENAME);
             logger.trace("Saving key store to file [" + keyStoreFile + "]");
             FileOutputStream fileOutputStream = null;

--- a/mockserver-examples/pom.xml
+++ b/mockserver-examples/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>3.9.2-SNAPSHOT</version>
+        <version>3.9.3-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-integration-testing/pom.xml
+++ b/mockserver-integration-testing/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>3.9.2-SNAPSHOT</version>
+        <version>3.9.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mockserver-maven-plugin-integration-tests/pom.xml
+++ b/mockserver-maven-plugin-integration-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>3.9.2-SNAPSHOT</version>
+        <version>3.9.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mockserver-maven-plugin/pom.xml
+++ b/mockserver-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>3.9.2-SNAPSHOT</version>
+        <version>3.9.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mockserver-netty/pom.xml
+++ b/mockserver-netty/pom.xml
@@ -3,7 +3,7 @@
 <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>3.9.2-SNAPSHOT</version>
+        <version>3.9.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mockserver-netty/pom.xml
+++ b/mockserver-netty/pom.xml
@@ -63,7 +63,11 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.2</version>
+        </dependency>
         <!-- logging -->
         <dependency> <!-- will map to any underlying logging framework -->
             <groupId>org.slf4j</groupId>
@@ -82,6 +86,11 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/mockserver-netty/src/main/java/org/mockserver/cli/Main.java
+++ b/mockserver-netty/src/main/java/org/mockserver/cli/Main.java
@@ -2,16 +2,18 @@ package org.mockserver.cli;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
+import org.apache.commons.cli.*;
+import org.apache.commons.io.FileUtils;
 import org.mockserver.logging.Logging;
 import org.mockserver.mockserver.MockServerBuilder;
 import org.mockserver.proxy.ProxyBuilder;
+import org.mockserver.socket.SSLFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.PrintStream;
-import java.util.Arrays;
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -19,26 +21,24 @@ import java.util.Map;
  */
 public class Main {
     public static final String PROXY_PORT_KEY = "proxyPort";
+    public static final String PROXY_PORT_KEY_DESCRIPTION = "specifies the HTTP and HTTPS port for the MockServer port unification is used to support HTTP and HTTPS on the same port";
+
     public static final String SERVER_PORT_KEY = "serverPort";
-    public static final String USAGE = "" +
-            "   java -jar <path to mockserver-jetty-jar-with-dependencies.jar> [-serverPort <port>] [-proxyPort <port>]" + System.getProperty("line.separator") +
-            "   " + System.getProperty("line.separator") +
-            "     valid options are:" + System.getProperty("line.separator") +
-            "        -serverPort <port>           specifies the HTTP and HTTPS port for the         " + System.getProperty("line.separator") +
-            "                                     MockServer port unification is used to            " + System.getProperty("line.separator") +
-            "                                     support HTTP and HTTPS on the same port           " + System.getProperty("line.separator") +
-            "                                                                                       " + System.getProperty("line.separator") +
-            "        -proxyPort <path>            specifies the HTTP, HTTPS, SOCKS and HTTP         " + System.getProperty("line.separator") +
-            "                                     CONNECT port for proxy, port unification          " + System.getProperty("line.separator") +
-            "                                     supports for all protocols on the same port       " + System.getProperty("line.separator");
+    public static final String SERVER_PORT_KEY_DESCRIPTION = "specifies the HTTP, HTTPS, SOCKS and HTTP CONNECT port for proxy, port unification supports for all protocols on the same port";
+
+    public static final String FILE_LOCATION_KEY = "jksPath";
+    public static final String FILE_LOCATION_KEY_DESCRIPTION = "Path to a Java KeyStore file containing your SSL Certificate. If jksPath is provided, keyPassword is also required";
+
+    public static final String KEY_STORE_PASSWORD = "keyPassword";
+    public static final String KEY_STORE_PASSWORD_DESCRIPTION = "KeyStore password";
+
 
     private static final Logger logger = LoggerFactory.getLogger(Main.class);
     @VisibleForTesting
     static ProxyBuilder httpProxyBuilder = new ProxyBuilder();
     @VisibleForTesting
     static MockServerBuilder mockServerBuilder = new MockServerBuilder();
-    @VisibleForTesting
-    static PrintStream outputPrintStream = System.out;
+
     @VisibleForTesting
     static boolean shutdownOnUsage = true;
     private static boolean usagePrinted = false;
@@ -53,65 +53,61 @@ public class Main {
     public static void main(String... arguments) {
         usagePrinted = false;
 
-        Map<String, Integer> parseIntegerArguments = new HashMap<String, Integer>();
+        Map<String, String> parseStringArguments = new HashMap<String, String>();
+        Options options = new Options();
+        options.addOption(OptionBuilder.withArgName("integer").hasArg().withDescription(SERVER_PORT_KEY_DESCRIPTION).create(SERVER_PORT_KEY));
+        options.addOption(OptionBuilder.withArgName("integer").hasArg().withDescription(PROXY_PORT_KEY_DESCRIPTION).create(PROXY_PORT_KEY));
+        options.addOption(OptionBuilder.withArgName("string").hasArg().withDescription(FILE_LOCATION_KEY_DESCRIPTION).create(FILE_LOCATION_KEY));
+        options.addOption(OptionBuilder.withArgName("string").hasArg().withDescription(KEY_STORE_PASSWORD_DESCRIPTION).create(KEY_STORE_PASSWORD));
 
-        parseArguments(parseIntegerArguments, arguments);
+        CommandLineParser parser = new BasicParser();
+        CommandLine cmd;
+        try {
+            cmd = parser.parse(options, arguments);
+        } catch (ParseException e) {
+            showUsage(options);
+            return;
+        }
 
         if (logger.isDebugEnabled()) {
             logger.debug(System.getProperty("line.separator") + System.getProperty("line.separator") + "Using command line options: " +
-                    Joiner.on(", ").withKeyValueSeparator("=").join(parseIntegerArguments) + System.getProperty("line.separator"));
+                    Joiner.on(", ").withKeyValueSeparator("=").join(parseStringArguments) + System.getProperty("line.separator"));
         }
         Logging.overrideLogLevel(System.getProperty("mockserver.logLevel"));
 
-        if (parseIntegerArguments.size() > 0) {
-            if (parseIntegerArguments.containsKey(PROXY_PORT_KEY)) {
-                httpProxyBuilder.withLocalPort(parseIntegerArguments.get(PROXY_PORT_KEY)).build();
-            }
-            if (parseIntegerArguments.containsKey(SERVER_PORT_KEY)) {
-                mockServerBuilder.withHTTPPort(parseIntegerArguments.get(SERVER_PORT_KEY)).build();
-            }
-        } else {
-            showUsage();
+        if (!(cmd.hasOption(PROXY_PORT_KEY) || cmd.hasOption(SERVER_PORT_KEY))) {
+            showUsage(options);
         }
-    }
 
-    private static Map<String, Integer> parseArguments(Map<String, Integer> parsedIntegerArguments, String... arguments) {
-        Iterator<String> argumentsIterator = Arrays.asList(arguments).iterator();
-        while (argumentsIterator.hasNext()) {
-            String argumentName = argumentsIterator.next();
-            if (argumentsIterator.hasNext()) {
-                String argumentValue = argumentsIterator.next();
-                if (!parsePort(parsedIntegerArguments, SERVER_PORT_KEY, argumentName, argumentValue)
-                        && !parsePort(parsedIntegerArguments, PROXY_PORT_KEY, argumentName, argumentValue)) {
-                    showUsage();
-                }
-            } else {
-                showUsage();
-            }
+        if (cmd.hasOption(PROXY_PORT_KEY)) {
+            httpProxyBuilder.withLocalPort(Integer.parseInt(cmd.getOptionValue(PROXY_PORT_KEY))).build();
         }
-        return parsedIntegerArguments;
-    }
+        if (cmd.hasOption(SERVER_PORT_KEY)) {
+            mockServerBuilder.withHTTPPort(Integer.parseInt(cmd.getOptionValue(SERVER_PORT_KEY))).build();
+        }
 
-    private static boolean parsePort(Map<String, Integer> parsedArguments, final String key, final String argumentName, final String argumentValue) {
-        if (argumentName.equals("-" + key)) {
+        if ((cmd.hasOption(FILE_LOCATION_KEY) ^ cmd.hasOption(KEY_STORE_PASSWORD))) {
+            showUsage(options);
+        } else if (cmd.hasOption(FILE_LOCATION_KEY) && cmd.hasOption(KEY_STORE_PASSWORD)) {
             try {
-                parsedArguments.put(key, Integer.parseInt(argumentValue));
-                return true;
-            } catch (NumberFormatException nfe) {
-                logger.error("Please provide a value integer for -" + key + ", [" + argumentValue + "] is not a valid integer", nfe);
+                FileUtils.copyFile(new File(cmd.getOptionValue(FILE_LOCATION_KEY)), new File(SSLFactory.KEY_STORE_FILENAME));
+            } catch (IOException e) {
+                logger.error("Error copying keystore" + e.getMessage());
+                showUsage(options);
             }
+
+            SSLFactory.KEY_STORE_PASSWORD = cmd.getOptionValue(KEY_STORE_PASSWORD);
         }
-        return false;
     }
 
-    private static void showUsage() {
-        if (!usagePrinted) {
-            outputPrintStream.println(USAGE);
-            if (shutdownOnUsage) {
-                System.exit(1);
-            }
-            usagePrinted = true;
+    private static void showUsage(Options options) {
+        HelpFormatter formatter = new HelpFormatter();
+        formatter.printHelp( "mockserver", options );
+        if (shutdownOnUsage) {
+            System.exit(1);
         }
     }
+
+
 
 }

--- a/mockserver-netty/src/main/java/org/mockserver/cli/Main.java
+++ b/mockserver-netty/src/main/java/org/mockserver/cli/Main.java
@@ -96,13 +96,13 @@ public class Main {
                 showUsage(options);
             }
 
-            SSLFactory.KEY_STORE_PASSWORD = cmd.getOptionValue(KEY_STORE_PASSWORD);
+            SSLFactory.keyStorePassword = cmd.getOptionValue(KEY_STORE_PASSWORD);
         }
     }
 
     private static void showUsage(Options options) {
         HelpFormatter formatter = new HelpFormatter();
-        formatter.printHelp( "mockserver", options );
+        formatter.printHelp("mockserver", options);
         if (shutdownOnUsage) {
             System.exit(1);
         }

--- a/mockserver-netty/src/main/java/org/mockserver/integration/ClientAndServer.java
+++ b/mockserver-netty/src/main/java/org/mockserver/integration/ClientAndServer.java
@@ -5,7 +5,6 @@ import org.mockserver.client.server.MockServerClient;
 import org.mockserver.mockserver.MockServer;
 import org.mockserver.socket.PortFactory;
 import org.mockserver.socket.SSLFactory;
-import sun.security.ntlm.Client;
 
 import java.io.File;
 import java.io.IOException;

--- a/mockserver-netty/src/main/java/org/mockserver/integration/ClientAndServer.java
+++ b/mockserver-netty/src/main/java/org/mockserver/integration/ClientAndServer.java
@@ -1,8 +1,14 @@
 package org.mockserver.integration;
 
+import org.apache.commons.io.FileUtils;
 import org.mockserver.client.server.MockServerClient;
 import org.mockserver.mockserver.MockServer;
 import org.mockserver.socket.PortFactory;
+import org.mockserver.socket.SSLFactory;
+import sun.security.ntlm.Client;
+
+import java.io.File;
+import java.io.IOException;
 
 /**
  * @author jamesdbloom
@@ -17,11 +23,26 @@ public class ClientAndServer extends MockServerClient {
 
     public ClientAndServer(Integer port) {
         super("localhost", port);
+
         mockServer = new MockServer(port);
+    }
+
+    public ClientAndServer(Integer port, String keystoreLocation, String keystorePassword) {
+        this(port);
+        try {
+            FileUtils.copyFile(new File(keystoreLocation), new File(SSLFactory.KEY_STORE_FILENAME));
+        } catch (IOException e) {
+            logger.error("Error copying keystore" + e.getMessage());
+        }
+
+        SSLFactory.keyStorePassword = keystorePassword;
     }
 
     public static ClientAndServer startClientAndServer(Integer port) {
         return new ClientAndServer(port);
+    }
+    public static ClientAndServer startClientAndServer(Integer port, String keystoreLocation, String keystorePassword) {
+        return new ClientAndServer(port, keystoreLocation, keystorePassword);
     }
 
     public boolean isRunning() {

--- a/mockserver-netty/src/test/java/org/mockserver/cli/MainTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/cli/MainTest.java
@@ -1,7 +1,10 @@
 package org.mockserver.cli;
 
+import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.StandardOutputStreamLog;
 import org.mockito.Mock;
 import org.mockserver.mockserver.MockServerBuilder;
 import org.mockserver.proxy.ProxyBuilder;
@@ -20,20 +23,19 @@ public class MainTest {
 
     private final static Integer SERVER_HTTP_PORT = PortFactory.findFreePort();
     private final static Integer PROXY_HTTP_PORT = PortFactory.findFreePort();
-
+    private final static String WHITESPACE_IN_OUTPUT = "\n                         ";
     @Mock
     private ProxyBuilder mockProxyBuilder;
     @Mock
     private MockServerBuilder mockMockServerBuilder;
-    @Mock
-    private PrintStream mockPrintStream;
+    @Rule
+    public final StandardOutputStreamLog log = new StandardOutputStreamLog();
 
     @Before
     public void setupMocks() {
         initMocks(this);
         Main.mockServerBuilder = mockMockServerBuilder;
         Main.httpProxyBuilder = mockProxyBuilder;
-        Main.outputPrintStream = mockPrintStream;
         Main.shutdownOnUsage = false;
 
         when(mockMockServerBuilder.withHTTPPort(anyInt())).thenReturn(mockMockServerBuilder);
@@ -82,21 +84,33 @@ public class MainTest {
     public void shouldPrintOutUsageForInvalidPort() {
         Main.main("-proxyPort", "1", "-invalidOption", "2");
 
-        verify(mockPrintStream).println(Main.USAGE);
+        assert log.getLog().contains("specifies the HTTP and HTTPS port for the"
+                + WHITESPACE_IN_OUTPUT
+                + "MockServer port unification is used to support"
+                + WHITESPACE_IN_OUTPUT
+                + "HTTP and HTTPS on the same port");
     }
 
     @Test
     public void shouldPrintOutUsageForMissingLastPort() {
         Main.main("-serverPort", "1", "-proxyPort");
 
-        verify(mockPrintStream).println(Main.USAGE);
+        assert log.getLog().contains("specifies the HTTP, HTTPS, SOCKS and HTTP CONNECT"
+            + WHITESPACE_IN_OUTPUT
+            + "port for proxy, port unification supports for all"
+            + WHITESPACE_IN_OUTPUT
+            + "protocols on the same port");
     }
 
     @Test
     public void shouldPrintOutUsageForMissingFirstPort() {
         Main.main("-serverPort", "-proxyPort", "2");
 
-        verify(mockPrintStream).println(Main.USAGE);
+        assert log.getLog().contains("specifies the HTTP, HTTPS, SOCKS and HTTP CONNECT"
+                + WHITESPACE_IN_OUTPUT
+                + "port for proxy, port unification supports for all"
+                + WHITESPACE_IN_OUTPUT
+                + "protocols on the same port");
     }
 
     @Test
@@ -104,8 +118,45 @@ public class MainTest {
         // using non static reference and constructor for coverage
         new Main().main();
 
-        verify(mockPrintStream).println(Main.USAGE);
+        assert log.getLog().contains("specifies the HTTP, HTTPS, SOCKS and HTTP CONNECT"
+                + WHITESPACE_IN_OUTPUT
+                + "port for proxy, port unification supports for all"
+                + WHITESPACE_IN_OUTPUT
+                + "protocols on the same port");
         verifyZeroInteractions(mockMockServerBuilder);
         verifyZeroInteractions(mockProxyBuilder);
+    }
+
+    @Test
+    public void shouldPrintOutUsageForJksPathAndNoPassword() {
+        Main.main("-proxyPort", "2", "-jksPath", "/dev/null");
+
+        assert log.getLog().contains("specifies the HTTP, HTTPS, SOCKS and HTTP CONNECT"
+                + WHITESPACE_IN_OUTPUT
+                + "port for proxy, port unification supports for all"
+                + WHITESPACE_IN_OUTPUT
+                + "protocols on the same port");
+    }
+
+    @Test
+    public void shouldPrintOutUsageForPasswordAndNoJksPath() {
+        Main.main("-proxyPort", "2", "-keyPassword", "password");
+
+        assert log.getLog().contains("specifies the HTTP, HTTPS, SOCKS and HTTP CONNECT"
+                + WHITESPACE_IN_OUTPUT
+                + "port for proxy, port unification supports for all"
+                + WHITESPACE_IN_OUTPUT
+                + "protocols on the same port");
+    }
+
+    @Test
+    public void shouldPrintOutUsageForInvalidJksPath() {
+        Main.main("-proxyPort", "2", "-jksPath", "/tmp/thisFileDoesNotExist");
+
+        assert log.getLog().contains("specifies the HTTP, HTTPS, SOCKS and HTTP CONNECT"
+                + WHITESPACE_IN_OUTPUT
+                + "port for proxy, port unification supports for all"
+                + WHITESPACE_IN_OUTPUT
+                + "protocols on the same port");
     }
 }

--- a/mockserver-proxy-war/pom.xml
+++ b/mockserver-proxy-war/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>3.9.2-SNAPSHOT</version>
+        <version>3.9.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mockserver-war/pom.xml
+++ b/mockserver-war/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>3.9.2-SNAPSHOT</version>
+        <version>3.9.3-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-war/src/test/java/org/mockserver/server/ClientServerWarNoContextPathIntegrationTest.java
+++ b/mockserver-war/src/test/java/org/mockserver/server/ClientServerWarNoContextPathIntegrationTest.java
@@ -40,7 +40,7 @@ public class ClientServerWarNoContextPathIntegrationTest extends AbstractClientS
         httpsConnector.setPort(SERVER_HTTPS_PORT);
         httpsConnector.setSecure(true);
         httpsConnector.setAttribute("keyAlias", SSLFactory.KEY_STORE_CERT_ALIAS);
-        httpsConnector.setAttribute("keystorePass", SSLFactory.KEY_STORE_PASSWORD);
+        httpsConnector.setAttribute("keystorePass", SSLFactory.keyStorePassword);
         httpsConnector.setAttribute("keystoreFile", new File(SSLFactory.KEY_STORE_FILENAME).getAbsoluteFile());
         httpsConnector.setAttribute("sslProtocol", "TLS");
         httpsConnector.setAttribute("clientAuth", false);

--- a/mockserver-war/src/test/java/org/mockserver/server/ClientServerWarWithContextPathIntegrationTest.java
+++ b/mockserver-war/src/test/java/org/mockserver/server/ClientServerWarWithContextPathIntegrationTest.java
@@ -40,7 +40,7 @@ public class ClientServerWarWithContextPathIntegrationTest extends AbstractClien
         httpsConnector.setPort(SERVER_HTTPS_PORT);
         httpsConnector.setSecure(true);
         httpsConnector.setAttribute("keyAlias", SSLFactory.KEY_STORE_CERT_ALIAS);
-        httpsConnector.setAttribute("keystorePass", SSLFactory.KEY_STORE_PASSWORD);
+        httpsConnector.setAttribute("keystorePass", SSLFactory.keyStorePassword);
         httpsConnector.setAttribute("keystoreFile", new File(SSLFactory.KEY_STORE_FILENAME).getAbsoluteFile());
         httpsConnector.setAttribute("sslProtocol", "TLS");
         httpsConnector.setAttribute("clientAuth", false);

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.mock-server</groupId>
     <artifactId>mockserver</artifactId>
-    <version>3.9.2-SNAPSHOT</version>
+    <version>3.9.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>MockServer</name>


### PR DESCRIPTION
It would be useful to have a static SSL certificate (i.e. one that does not change on each start-up), as such we have made some efforts to pass in the JKS and password on the command line when starting the mockserver.

Actual contributors: @downeyfe @benlancaster @hbk619