### PR TITLE
Support port 0 (JVM-assigned free port)

### DIFF
--- a/mockserver-netty/src/main/java/org/mockserver/integration/ClientAndServer.java
+++ b/mockserver-netty/src/main/java/org/mockserver/integration/ClientAndServer.java
@@ -2,22 +2,27 @@ package org.mockserver.integration;
 
 import org.mockserver.client.server.MockServerClient;
 import org.mockserver.mockserver.MockServer;
-import org.mockserver.socket.PortFactory;
 
 /**
  * @author jamesdbloom
  */
 public class ClientAndServer extends MockServerClient {
 
-    private MockServer mockServer;
+    private final MockServer mockServer;
 
     public ClientAndServer() {
-        this(PortFactory.findFreePort());
+        this(0);
     }
 
     public ClientAndServer(Integer port) {
-        super("localhost", port);
-        mockServer = new MockServer(port);
+        this(new MockServer(port));
+    }
+
+    // have to use this extra constructor to grab the port from the already-started server since since java won't allow us to assign
+    // this.mockServer before the call to super(), which itself requires the port assigned by the call to new MockServer(port).
+    protected ClientAndServer(MockServer server) {
+        super("localhost", server.getPort());
+        this.mockServer = server;
     }
 
     public static ClientAndServer startClientAndServer(Integer port) {
@@ -26,6 +31,10 @@ public class ClientAndServer extends MockServerClient {
 
     public boolean isRunning() {
         return mockServer.isRunning();
+    }
+
+    public int getPort() {
+        return mockServer.getPort();
     }
 
 }

--- a/mockserver-netty/src/main/java/org/mockserver/mockserver/MockServer.java
+++ b/mockserver-netty/src/main/java/org/mockserver/mockserver/MockServer.java
@@ -14,7 +14,9 @@ import org.mockserver.mock.MockServerMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * An HTTP server that sends back the content of the received HTTP request
@@ -43,17 +45,23 @@ public class MockServer {
         if (port == null) {
             throw new IllegalStateException("You must specify a port");
         }
-        this.port = port;
 
         hasStarted = SettableFuture.create();
         bossGroup = new NioEventLoopGroup();
         workerGroup = new NioEventLoopGroup();
 
+        // capture the assigned port from the separate thread that starts the server
+        final AtomicInteger assignedPort = new AtomicInteger(port);
+
         new Thread(new Runnable() {
             @Override
             public void run() {
                 try {
-                    logger.info("MockServer starting up on port: " + port);
+                    if (port == 0) {
+                        logger.info("MockServer starting up on a JVM-assigned port");
+                    } else {
+                        logger.info("MockServer starting up on port: {}", port);
+                    }
 
                     Channel httpChannel = new ServerBootstrap()
                             .group(bossGroup, workerGroup)
@@ -65,6 +73,16 @@ public class MockServer {
                             .bind(port)
                             .sync()
                             .channel();
+
+                    // cast the localAddress to an InetSocketAddress, as instructed by the localAddress() javadoc
+                    InetSocketAddress localAddress = (InetSocketAddress) httpChannel.localAddress();
+
+                    // get the actual assigned port from netty. if the passed-in port parameter was non-zero, this should be the same (assuming
+                    // the port is free and the server was started successfully). if the incoming port was zero, the JVM will assign a free
+                    // port automatically.
+                    assignedPort.set(localAddress.getPort());
+
+                    logger.info("MockServer successfully started on port: {}", assignedPort.get());
 
                     hasStarted.set("STARTED");
 
@@ -86,6 +104,8 @@ public class MockServer {
         } catch (Exception e) {
             logger.debug("Exception while waiting for proxy to complete starting up", e);
         }
+
+        this.port = assignedPort.get();
     }
 
     public void stop() {

--- a/mockserver-netty/src/test/java/org/mockserver/integration/ClientAndServerIntegrationTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/integration/ClientAndServerIntegrationTest.java
@@ -15,14 +15,17 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
  */
 public class ClientAndServerIntegrationTest extends AbstractClientServerSharedClassloadersAndTestClasspathIntegrationTest {
 
-    private static final int SERVER_HTTP_PORT = PortFactory.findFreePort();
+    private static int serverHttpPort;
     private final static int TEST_SERVER_HTTP_PORT = PortFactory.findFreePort();
     private static EchoServer httpEchoServer;
 
     @BeforeClass
     public static void startServer() throws InterruptedException, ExecutionException {
         // start mock server and client
-        mockServerClient = startClientAndServer(SERVER_HTTP_PORT);
+        ClientAndServer clientAndServer = startClientAndServer(0);
+
+        serverHttpPort = clientAndServer.getPort();
+        mockServerClient = clientAndServer;
 
         // start echo servers
         httpEchoServer = new EchoServer(TEST_SERVER_HTTP_PORT);
@@ -41,12 +44,12 @@ public class ClientAndServerIntegrationTest extends AbstractClientServerSharedCl
 
     @Override
     public int getMockServerPort() {
-        return SERVER_HTTP_PORT;
+        return serverHttpPort;
     }
 
     @Override
     public int getMockServerSecurePort() {
-        return SERVER_HTTP_PORT;
+        return serverHttpPort;
     }
 
     @Override

--- a/mockserver-netty/src/test/java/org/mockserver/mockserver/MockServerBuilderTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/mockserver/MockServerBuilderTest.java
@@ -5,6 +5,7 @@ import org.mockserver.socket.PortFactory;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
 
 /**
  * @author jamesdbloom
@@ -22,6 +23,19 @@ public class MockServerBuilderTest {
         try {
             // then
             assertThat(mockServer.getPort(), is(port));
+        } finally {
+            mockServer.stop();
+        }
+    }
+
+    @Test
+    public void testPortZero() {
+        // when
+        MockServer mockServer = new MockServerBuilder().withHTTPPort(0).build();
+
+        try {
+            // then
+            assertThat(mockServer.getPort(), not(0));
         } finally {
             mockServer.stop();
         }


### PR DESCRIPTION
This PR allows the JVM to assign a free, open port, so you can start a server like this:
```java
MockServer mockServer = new MockServer(0);
int port = mockServer.getPort(); // port will not be 0
```