### PR TITLE
Update activesupport version to 4.2.0

### DIFF
--- a/mockserver-client-ruby/mockserver-client.gemspec
+++ b/mockserver-client-ruby/mockserver-client.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'hashie', '~> 3.0'
   spec.add_dependency 'json', '~> 1.8.1'
-  spec.add_dependency 'activesupport', '~> 4.1.10'
+  spec.add_dependency 'activesupport', '~> 4.2.0'
   spec.add_dependency 'rest-client', '~> 1.7.2'
   spec.add_dependency 'logging_factory', '~> 0.0.2'
   spec.add_dependency 'thor', '~> 0.19.1'


### PR DESCRIPTION
@jamesdbloom Can we update activesupport version to the latest? I tested this locally and it worked. the previous versions are backward compatible with ```daocore```. Also can we release ```1.0.4``` version of the client after this change. Thanks a lot. 