### PR TITLE
Support for DELETE, HEAD, OPTIONS, TRACE HTTP methods

### DIFF
--- a/mockserver-war/src/main/java/org/mockserver/server/MockServerServlet.java
+++ b/mockserver-war/src/main/java/org/mockserver/server/MockServerServlet.java
@@ -41,14 +41,37 @@ public class MockServerServlet extends HttpServlet {
     private VerificationSerializer verificationSerializer = new VerificationSerializer();
     private VerificationSequenceSerializer verificationSequenceSerializer = new VerificationSequenceSerializer();
 
+    @Override
     public void doGet(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
         mockResponse(httpServletRequest, httpServletResponse);
     }
 
+    @Override
     public void doPost(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
         mockResponse(httpServletRequest, httpServletResponse);
     }
 
+    @Override
+    protected void doHead(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
+        mockResponse(httpServletRequest, httpServletResponse);
+    }
+
+    @Override
+    protected void doDelete(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
+        mockResponse(httpServletRequest, httpServletResponse);
+    }
+
+    @Override
+    protected void doOptions(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
+        mockResponse(httpServletRequest, httpServletResponse);
+    }
+
+    @Override
+    protected void doTrace(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
+        mockResponse(httpServletRequest, httpServletResponse);
+    }
+
+    @Override
     public void doPut(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
 
         try {


### PR DESCRIPTION
I was using DELETE in test and noticed its absent from `MockServerServlet`. I think other methods might also be useful even though use cases for them are rare.

There were no unit tests for POST and PUT (only for GET) so I didn't provide unit tests for added methods as they all delegate to `mockResponse()` like `doGet` does)