### PR TITLE
Integration test to verify interrupted request

### DIFF
--- a/mockserver-integration-testing/src/main/java/org/mockserver/integration/server/AbstractClientServerIntegrationTest.java
+++ b/mockserver-integration-testing/src/main/java/org/mockserver/integration/server/AbstractClientServerIntegrationTest.java
@@ -3613,6 +3613,33 @@ public abstract class AbstractClientServerIntegrationTest {
     }
 
     @Test
+    public void shouldEnsureThatInterruptedRequestsAreVerifiable() throws Exception {
+        final HttpRequest delayedRequest = request("/delayed");
+
+        mockServerClient
+                .when(
+                        delayedRequest
+                )
+                .respond(
+                        response("delayed data")
+                                .withDelay(new Delay(TimeUnit.SECONDS, 3))
+                );
+
+        Future<HttpResponse> delayedFuture = Executors.newSingleThreadExecutor().submit(new Callable<HttpResponse>() {
+            @Override
+            public HttpResponse call() throws Exception {
+                return httpClient.sendRequest(outboundRequest("localhost", getMockServerPort(), servletContext, delayedRequest));
+            }
+        });
+
+        Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS); // Let request reach server
+
+        delayedFuture.cancel(true); // Then interrupt requesting thread
+
+        mockServerClient.verify(delayedRequest); // We should be able to verify request that reached server even though its later interrupted
+    }
+
+    @Test
     public void shouldEnsureThatRequestDelaysDoNotAffectOtherRequests() throws Exception {
         mockServerClient
                 .when(


### PR DESCRIPTION
Consider following use-case:
- Create a long-running request
- In case if its timed-out on client - client interrupts it
- Its still useful to verify that request reached server to test timeout handling but it doesn't work currently

BTW, this was in the log:

```
SEVERE: The web application [/mockserver] is still processing a request that has yet to finish. This is very likely to create a memory leak. You can control the time allowed for requests to finish by using the unloadDelay attribute of the standard Context implementation.
```
