### PR TITLE
Add character set support on responses

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/mappers/ContentTypeMapper.java
+++ b/mockserver-core/src/main/java/org/mockserver/mappers/ContentTypeMapper.java
@@ -1,11 +1,33 @@
 package org.mockserver.mappers;
 
 import com.google.common.base.Strings;
+import io.netty.handler.codec.http.HttpMessage;
+import org.mockserver.model.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletRequest;
+import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
+import java.util.List;
 
 /**
  * @author jamesdbloom
  */
 public class ContentTypeMapper {
+    private static final Logger logger = LoggerFactory.getLogger(ContentTypeMapper.class);
+
+    /**
+     * The default character set for an HTTP message, if none is specified in the Content-Type header. From the HTTP 1.1 specification
+     * section 3.7.1 (http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7.1):
+     * <pre>
+     *     The "charset" parameter is used with some media types to define the character set (section 3.4) of the data.
+     *     When no explicit charset parameter is provided by the sender, media subtypes of the "text" type are defined to
+     *     have a default charset value of "ISO-8859-1" when received via HTTP. Data in character sets other than
+     *     "ISO-8859-1" or its subsets MUST be labeled with an appropriate charset value.
+     * </pre>
+     */
+    public static final Charset DEFAULT_HTTP_CHARACTER_SET = Charset.forName("ISO-8859-1");
 
     public static boolean isBinary(String contentTypeHeader) {
         boolean binary = false;
@@ -41,5 +63,96 @@ public class ContentTypeMapper {
             }
         }
         return binary;
+    }
+
+    /**
+     * Identifies the character set from the Content-Type header in the HttpMessage. If no Content-Type header or character set
+     * exists, or the character set is not supported, returns the {@link ContentTypeMapper#DEFAULT_HTTP_CHARACTER_SET}.
+     *
+     * @param httpMessage HTTP message
+     * @return character set from message headers, or null
+     */
+    public static Charset identifyCharsetFromHttpMessage(HttpMessage httpMessage) {
+        Charset charset = null;
+
+        String contentTypeHeader = httpMessage.headers().get("Content-Type");
+        if (contentTypeHeader != null) {
+            charset = getCharsetFromContentTypeHeader(contentTypeHeader);
+        }
+
+        if (charset == null) {
+            charset = DEFAULT_HTTP_CHARACTER_SET;
+            logger.debug("No character set specified in Content-Type header. Using default charset {}.", charset);
+        }
+
+        return charset;
+    }
+
+    /**
+     * Identifies the character set from the Content-Type header in the HttpServletRequest. If no Content-Type header or character set
+     * exists, or the character set is not supported, returns the {@link ContentTypeMapper#DEFAULT_HTTP_CHARACTER_SET}.
+     *
+     * @param servletRequest HTTP request
+     * @return character set from request headers, or null
+     */
+    public static Charset identifyCharsetFromServletRequest(HttpServletRequest servletRequest) {
+        Charset charset = null;
+
+        String contentTypeHeader = servletRequest.getHeader("Content-Type");
+        if (contentTypeHeader != null) {
+            charset = getCharsetFromContentTypeHeader(contentTypeHeader);
+        }
+
+        if (charset == null) {
+            charset = DEFAULT_HTTP_CHARACTER_SET;
+            logger.debug("No character set specified in Content-Type header. Using default charset {}.", charset);
+        }
+
+        return charset;
+    }
+
+    /**
+     * Identifies the character set from the Content-Type header in the HttpResponse. If no Content-Type header or character set
+     * exists, or the character set is not supported, returns the {@link ContentTypeMapper#DEFAULT_HTTP_CHARACTER_SET}.
+     *
+     * @param httpResponse HTTP response
+     * @return character set from response headers, or null
+     */
+    public static Charset identifyCharsetFromResponse(HttpResponse httpResponse) {
+        Charset charset = null;
+        List<String> contentTypeHeaderValues = httpResponse.getHeader("Content-Type");
+        if (contentTypeHeaderValues != null && !contentTypeHeaderValues.isEmpty()) {
+            charset = getCharsetFromContentTypeHeader(contentTypeHeaderValues.get(0));
+        }
+
+        if (charset == null) {
+            charset = DEFAULT_HTTP_CHARACTER_SET;
+            logger.debug("No character set specified in Content-Type header. Using default charset {}.", charset);
+        }
+
+        return charset;
+    }
+
+    /**
+     * Examines the Content-Type string to determine the charset. If there is no 'charset=' text in the header, or if the specified charset
+     * is not supported, returns null.
+     *
+     * @param contentType the value of a Content-Type header
+     * @return the charset indicated by the Content-Type header, or null if no charset is specified
+     */
+    private static Charset getCharsetFromContentTypeHeader(String contentType) {
+        if (contentType == null) {
+            return null;
+        }
+
+        int charsetIndex = contentType.lastIndexOf("charset=");
+        String charsetString = contentType.substring(charsetIndex + "charset=".length());
+        try {
+            return Charset.forName(charsetString);
+        } catch (UnsupportedCharsetException e) {
+            logger.info("Unsupported character set {} in Content-Type header: {}.", charsetString, contentType);
+
+            return null;
+        }
     }
 }

--- a/mockserver-core/src/main/java/org/mockserver/mappers/ContentTypeMapper.java
+++ b/mockserver-core/src/main/java/org/mockserver/mappers/ContentTypeMapper.java
@@ -70,7 +70,7 @@ public class ContentTypeMapper {
      * exists, or the character set is not supported, returns the {@link ContentTypeMapper#DEFAULT_HTTP_CHARACTER_SET}.
      *
      * @param httpMessage HTTP message
-     * @return character set from message headers, or null
+     * @return character set from the message headers, or {@link ContentTypeMapper#DEFAULT_HTTP_CHARACTER_SET} if no charset is specified
      */
     public static Charset identifyCharsetFromHttpMessage(HttpMessage httpMessage) {
         Charset charset = null;
@@ -93,7 +93,7 @@ public class ContentTypeMapper {
      * exists, or the character set is not supported, returns the {@link ContentTypeMapper#DEFAULT_HTTP_CHARACTER_SET}.
      *
      * @param servletRequest HTTP request
-     * @return character set from request headers, or null
+     * @return character set from the servlet request headers, or {@link ContentTypeMapper#DEFAULT_HTTP_CHARACTER_SET} if no charset is specified
      */
     public static Charset identifyCharsetFromServletRequest(HttpServletRequest servletRequest) {
         Charset charset = null;
@@ -116,7 +116,7 @@ public class ContentTypeMapper {
      * exists, or the character set is not supported, returns the {@link ContentTypeMapper#DEFAULT_HTTP_CHARACTER_SET}.
      *
      * @param httpResponse HTTP response
-     * @return character set from response headers, or null
+     * @return character set from the response headers, or {@link ContentTypeMapper#DEFAULT_HTTP_CHARACTER_SET} if no charset is specified
      */
     public static Charset identifyCharsetFromResponse(HttpResponse httpResponse) {
         Charset charset = null;

--- a/mockserver-core/src/main/java/org/mockserver/mappers/HttpServletToMockServerRequestMapper.java
+++ b/mockserver-core/src/main/java/org/mockserver/mappers/HttpServletToMockServerRequestMapper.java
@@ -1,6 +1,5 @@
 package org.mockserver.mappers;
 
-import com.google.common.base.Charsets;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.QueryStringDecoder;
 import org.apache.commons.lang3.StringUtils;
@@ -8,6 +7,7 @@ import org.mockserver.model.*;
 import org.mockserver.streams.IOStreamUtils;
 
 import javax.servlet.http.HttpServletRequest;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -48,7 +48,10 @@ public class HttpServletToMockServerRequestMapper {
             if (ContentTypeMapper.isBinary(httpServletRequest.getHeader(HttpHeaders.Names.CONTENT_TYPE))) {
                 httpRequest.withBody(new BinaryBody(bodyBytes));
             } else {
-                httpRequest.withBody(new StringBody(new String(bodyBytes, Charsets.UTF_8), bodyBytes));
+                Charset charsetFromRequest = ContentTypeMapper.identifyCharsetFromServletRequest(httpServletRequest);
+                String body = new String(bodyBytes, charsetFromRequest);
+
+                httpRequest.withBody(new StringBody(body, charsetFromRequest));
             }
         }
     }

--- a/mockserver-core/src/main/java/org/mockserver/model/HttpResponse.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/HttpResponse.java
@@ -2,6 +2,7 @@ package org.mockserver.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import java.nio.charset.Charset;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
@@ -50,9 +51,10 @@ public class HttpResponse extends Action {
     }
 
     /**
-     * Set response body to return as a simple UTF-8 string response body
+     * Set response body to return as a string response body. The character set will be determined by the Content-Type header
+     * on the response. To force the character set, use {@link #withBody(String, Charset)}.
      *
-     * @param body a UTF-8 string
+     * @param body a string
      */
     public HttpResponse withBody(String body) {
         if (body != null) {
@@ -60,6 +62,21 @@ public class HttpResponse extends Action {
         }
         return this;
     }
+
+    /**
+     * Set response body to return a string response body with the specified encoding. <b>Note:</b> The character set of the
+     * response will be forced to the specified charset, even if the Content-Type header specifies otherwise.
+     *
+     * @param body a string
+     * @param charset character set the string will be encoded in
+     */
+    public HttpResponse withBody(String body, Charset charset) {
+        if (body != null) {
+            this.body = new StringBody(body, charset);
+        }
+        return this;
+    }
+
 
     /**
      * Set response body to return as binary such as a pdf or image

--- a/mockserver-core/src/main/java/org/mockserver/model/StringBody.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/StringBody.java
@@ -1,5 +1,9 @@
 package org.mockserver.model;
 
+import org.mockserver.mappers.ContentTypeMapper;
+
+import java.nio.charset.Charset;
+
 /**
  * @author jamesdbloom
  */
@@ -8,24 +12,75 @@ public class StringBody extends Body<String> {
     private final String value;
     private final byte[] rawBinaryData;
 
+    /**
+     * When present, the contents of this StringBody will be forced to the specified character set.
+     */
+    private final Charset charset;
+
+    /**
+     * @deprecated use {@link #StringBody(String, Charset)}
+     */
+    @Deprecated
     public StringBody(String value, byte[] rawBinaryData) {
         super(Type.STRING);
         this.value = value;
         this.rawBinaryData = rawBinaryData;
+        charset = null;
     }
 
+    /**
+     * Creates a StringBody that will store the specified value in the {@link ContentTypeMapper#DEFAULT_HTTP_CHARACTER_SET}.
+     * Use {@link #StringBody(String, Charset)} to explicitly set the character set of the encoded string.
+     *
+     * @param value body contents
+     */
     public StringBody(String value) {
         super(Type.STRING);
         this.value = value;
+
         if (value != null) {
-            this.rawBinaryData = value.getBytes();
+            this.rawBinaryData = value.getBytes(ContentTypeMapper.DEFAULT_HTTP_CHARACTER_SET);
         } else {
             this.rawBinaryData = new byte[0];
         }
+
+        charset = null;
+    }
+
+    /**
+     * Creates a StringBody that will store the specified value in the specified charset.
+     *
+     * @param value body contents
+     * @param charset character set to encode the contents in when generating the body byte[] contents
+     */
+    public StringBody(String value, Charset charset) {
+        super(Type.STRING);
+        this.value = value;
+
+        if (value != null) {
+            this.rawBinaryData = value.getBytes(charset);
+        } else {
+            this.rawBinaryData = new byte[0];
+        }
+
+        this.charset = charset;
     }
 
     public static StringBody exact(String body) {
         return new StringBody(body);
+    }
+
+    public static StringBody exact(String body, Charset charset) {
+        return new StringBody(body, charset);
+    }
+
+    /**
+     * Returns the charset of this StringBody, if it was explicitly set.
+     *
+     * @return charset associated with this StringBody, or null if one was not specified
+     */
+    public Charset getCharset() {
+        return charset;
     }
 
     public String getValue() {

--- a/mockserver-netty/src/main/java/org/mockserver/codec/MockServerRequestDecoder.java
+++ b/mockserver-netty/src/main/java/org/mockserver/codec/MockServerRequestDecoder.java
@@ -34,9 +34,10 @@ public class MockServerRequestDecoder extends MessageToMessageDecoder<FullHttpRe
         if (fullHttpRequest != null) {
             setMethod(httpRequest, fullHttpRequest);
 
-            Charset charsetFromRequest = ContentTypeMapper.identifyCharsetFromHttpMessage(fullHttpRequest);
-
-            QueryStringDecoder queryStringDecoder = new QueryStringDecoder(fullHttpRequest.getUri(), charsetFromRequest);
+            // URL query strings are nominally supposed to be US-ASCII, with all non-US-ASCII characters URL-escaped. some
+            // servers do allow UTF-8 encoding, so use the default specified by the netty QueryStringDecoder (UTF-8). all
+            // US-ASCII query strings will be properly decoded when interpreted as UTF-8.
+            QueryStringDecoder queryStringDecoder = new QueryStringDecoder(fullHttpRequest.getUri());
             setPath(httpRequest, queryStringDecoder);
             setQueryString(httpRequest, queryStringDecoder);
 

--- a/mockserver-netty/src/main/java/org/mockserver/codec/MockServerRequestDecoder.java
+++ b/mockserver-netty/src/main/java/org/mockserver/codec/MockServerRequestDecoder.java
@@ -1,6 +1,5 @@
 package org.mockserver.codec;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Splitter;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageDecoder;
@@ -12,6 +11,7 @@ import org.mockserver.mappers.ContentTypeMapper;
 import org.mockserver.model.*;
 import org.mockserver.url.URLParser;
 
+import java.nio.charset.Charset;
 import java.util.List;
 
 import static io.netty.handler.codec.http.HttpHeaders.Names.COOKIE;
@@ -29,20 +29,22 @@ public class MockServerRequestDecoder extends MessageToMessageDecoder<FullHttpRe
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, FullHttpRequest fullHttpResponse, List<Object> out) {
+    protected void decode(ChannelHandlerContext ctx, FullHttpRequest fullHttpRequest, List<Object> out) {
         HttpRequest httpRequest = new HttpRequest();
-        if (fullHttpResponse != null) {
-            setMethod(httpRequest, fullHttpResponse);
+        if (fullHttpRequest != null) {
+            setMethod(httpRequest, fullHttpRequest);
 
-            QueryStringDecoder queryStringDecoder = new QueryStringDecoder(fullHttpResponse.getUri());
+            Charset charsetFromRequest = ContentTypeMapper.identifyCharsetFromHttpMessage(fullHttpRequest);
+
+            QueryStringDecoder queryStringDecoder = new QueryStringDecoder(fullHttpRequest.getUri(), charsetFromRequest);
             setPath(httpRequest, queryStringDecoder);
             setQueryString(httpRequest, queryStringDecoder);
 
-            setBody(httpRequest, fullHttpResponse);
-            setHeaders(httpRequest, fullHttpResponse);
-            setCookies(httpRequest, fullHttpResponse);
+            setBody(httpRequest, fullHttpRequest);
+            setHeaders(httpRequest, fullHttpRequest);
+            setCookies(httpRequest, fullHttpRequest);
 
-            httpRequest.setKeepAlive(isKeepAlive(fullHttpResponse));
+            httpRequest.setKeepAlive(isKeepAlive(fullHttpRequest));
             httpRequest.setSecure(isSecure);
         }
         out.add(httpRequest);
@@ -60,15 +62,18 @@ public class MockServerRequestDecoder extends MessageToMessageDecoder<FullHttpRe
         httpRequest.withQueryStringParameters(queryStringDecoder.parameters());
     }
 
-    private void setBody(HttpRequest httpRequest, FullHttpRequest fullHttpResponse) {
-        if (fullHttpResponse.content() != null && fullHttpResponse.content().readableBytes() > 0) {
-            byte[] bodyBytes = new byte[fullHttpResponse.content().readableBytes()];
-            fullHttpResponse.content().readBytes(bodyBytes);
+    private void setBody(HttpRequest httpRequest, FullHttpRequest fullHttpRequest) {
+        if (fullHttpRequest.content() != null && fullHttpRequest.content().readableBytes() > 0) {
+            byte[] bodyBytes = new byte[fullHttpRequest.content().readableBytes()];
+            fullHttpRequest.content().readBytes(bodyBytes);
             if (bodyBytes.length > 0) {
-                if (ContentTypeMapper.isBinary(fullHttpResponse.headers().get(HttpHeaders.Names.CONTENT_TYPE))) {
+                if (ContentTypeMapper.isBinary(fullHttpRequest.headers().get(HttpHeaders.Names.CONTENT_TYPE))) {
                     httpRequest.withBody(new BinaryBody(bodyBytes));
                 } else {
-                    httpRequest.withBody(new StringBody(new String(bodyBytes, Charsets.UTF_8), bodyBytes));
+                    Charset charsetFromRequest = ContentTypeMapper.identifyCharsetFromHttpMessage(fullHttpRequest);
+                    String body = new String(bodyBytes, charsetFromRequest);
+
+                    httpRequest.withBody(new StringBody(body, charsetFromRequest));
                 }
             }
         }


### PR DESCRIPTION
I ran into an issue where my tests were failing on Windows but not on Linux. After some investigation, I determined that the culprit was the HttpResponse.withBody(String) method. The method stated that it would encode strings as UTF-8, but in fact was encoding strings using the platform default charset, which is often UTF-8 in Linux but varies considerably on Windows. In my case, it was defaulting to windows-1252, which encodes some common characters such as the euro sign differently than UTF-8.

I implemented a few changes to standardize and improve the encoding of Strings. Instead of always using the platform default character set to encode Strings (the behavior of String.getBytes() without a charset parameter), this PR now allows you to specify a character set by either:
- Adding a Content-Type header with a charset. This is the preferred option, as it is what the HTTP standard requires for non-default charsets.
- Explicitly specifying the charset in the withBody() call or the StringBody() constructor. Using this option will force the charset, even if the Content-Type is absent or contradicts the specified charset.

If no character set is specified using one of the above options, the String will be encoded using ISO-8859-1, which is what the HTTP spec specifies in [section 3.7.1](http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7.1):
> The "charset" parameter is used with some media types to define the character set (section 3.4)  of the data. When no explicit charset parameter is provided by the sender, media subtypes of the "text" type are defined to have a default charset value of "ISO-8859-1" when received via HTTP. Data in character sets other than "ISO-8859-1" or its subsets MUST be labeled with an appropriate charset value.

This change also avoids unnecessarily Base64 encoding, then immediately unencoding, BinaryBody body types before adding them to a response body.