### PR TITLE
Additional Eclipse project files to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ Thumbs.db
 # Eclipse config files #
 ########################
 .project
+.classpath
+.settings
 
 # Maven build artifacts files #
 ###############################


### PR DESCRIPTION
With ignoring such files, it's more easy to merge a cloned repository, if working with Eclipse instead of IntelliJ. (I had to throw away and replace my last try)