### PR TITLE
Bump netty from 4.0.28.Final to 4.0.29.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <!-- tomcat version &gt; 7.0.56 causes SSL to fail -->
         <tomcat.version>7.0.56</tomcat.version>
         <jackson.version>2.5.3</jackson.version>
-        <netty.version>4.0.28.Final</netty.version>
+        <netty.version>4.0.29.Final</netty.version>
         <boucycastle.verion>1.52</boucycastle.verion>
         <spring.version>4.1.6.RELEASE</spring.version>
         <skipTests>false</skipTests>


### PR DESCRIPTION
netty 4.0.29.Final was released a couple days ago. I ran mvn test with the new version and everything was okay.