### PR TITLE
Fix Bad Request errors in the Ruby Client

### DIFF
--- a/mockserver-client-ruby/lib/mockserver/abstract_client.rb
+++ b/mockserver-client-ruby/lib/mockserver/abstract_client.rb
@@ -26,7 +26,7 @@ module MockServer
     def initialize(host, port)
       fail 'Cannot instantiate AbstractClient class. You must subclass it.' if self.class == AbstractClient
       fail 'Host/port must not be nil' unless host && port
-      @base   = RestClient::Resource.new("http://#{host}:#{port}")
+      @base   = RestClient::Resource.new("http://#{host}:#{port}", headers: { 'Content-Type' => 'application/json' })
       @logger = ::LoggingFactory::DEFAULT_FACTORY.log(self.class)
     end
 

--- a/mockserver-client-ruby/spec/mockserver/mock_client_spec.rb
+++ b/mockserver-client-ruby/spec/mockserver/mock_client_spec.rb
@@ -12,10 +12,10 @@ describe MockServer::MockServerClient do
     client.logger = LoggingFactory::DEFAULT_FACTORY.log('test', output: 'tmp.log', truncate: true)
 
     # Stub requests
-    stub_request(:put, /.+\/expectation/).with(body: register_expectation_json).to_return(status: 201)
-    stub_request(:put, /.+\/clear/).with(body: search_request_json).to_return(status: 202)
-    stub_request(:put, /.+\/reset/).to_return(status: 202)
-    stub_request(:put, /.+\/retrieve/).with(body: search_request_json).to_return(body: '', status: 200)
+    stub_request(:put, /.+\/expectation/).with(body: register_expectation_json, headers: { 'Content-Type' => 'application/json' }).to_return(status: 201)
+    stub_request(:put, /.+\/clear/).with(body: search_request_json, headers: { 'Content-Type' => 'application/json' }).to_return(status: 202)
+    stub_request(:put, /.+\/reset/).with(headers: { 'Content-Type' => 'application/json' }).to_return(status: 202)
+    stub_request(:put, /.+\/retrieve/).with(body: search_request_json, headers: { 'Content-Type' => 'application/json' }).to_return(body: '', status: 200)
   end
 
   it 'registers an expectation correctly' do


### PR DESCRIPTION
by adding a application/json Content-Type header.

Without this the ruby client doesn't work on my system because it sends requests like:
```json
{
  "method" : "PUT",
  "path" : "/retrieve",
  "headers" : [ {
    "name" : "Accept",
    "values" : [ "*/*; q=0.5, application/xml" ]
  }, {
    "name" : "Accept-Encoding",
    "values" : [ "gzip, deflate" ]
  }, {
    "name" : "Content-Length",
    "values" : [ "2" ]
  }, {
    "name" : "User-Agent",
    "values" : [ "Ruby" ]
  }, {
    "name" : "Host",
    "values" : [ "192.168.99.101:32780" ]
  }, {
    "name" : "Content-Type",
    "values" : [ "application/x-www-form-urlencoded" ]
  } ],
  "keepAlive" : true,
  "secure" : false,
  "body" : {
    "type" : "BINARY",
    "value" : "e30="
  }
}
```

Which causes a `java.lang.RuntimeException: Exception while parsing response [e30=] for http response httpRequest, Caused by: com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'e30': was expecting ('true', 'false' or 'null')
 at [Source: e30=; line: 1, column: 4]`