### PR TITLE
Save expectations to a file when server exists and load them at start.

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/mock/MockServerMatcher.java
+++ b/mockserver-core/src/main/java/org/mockserver/mock/MockServerMatcher.java
@@ -25,8 +25,16 @@ import java.util.regex.Pattern;
  */
 public class MockServerMatcher extends ObjectWithReflectiveEqualsHashCodeToString {
 
-    protected final List<Expectation> expectations = Collections.synchronizedList(new ArrayList<Expectation>());
+    protected final List<Expectation> expectations;
     private Logger requestLogger = LoggerFactory.getLogger("REQUEST");
+
+    public MockServerMatcher() {
+        this(new ArrayList<Expectation>());
+    }
+
+    public MockServerMatcher(List<Expectation> expectations) {
+        this.expectations = Collections.synchronizedList(expectations);
+    }
 
     public Expectation when(HttpRequest httpRequest) {
         return when(httpRequest, Times.unlimited(), TimeToLive.unlimited());
@@ -120,4 +128,9 @@ public class MockServerMatcher extends ObjectWithReflectiveEqualsHashCodeToStrin
             return serializedExpectation;
         }
     }
+
+    public List<Expectation> getExpectations() {
+        return new ArrayList<Expectation>(this.expectations);
+    }
+
 }

--- a/mockserver-netty/src/main/java/org/mockserver/cli/Main.java
+++ b/mockserver-netty/src/main/java/org/mockserver/cli/Main.java
@@ -16,6 +16,7 @@ import java.util.*;
  */
 public class Main {
     public static final String SERVER_PORT_KEY = "serverPort";
+    public static final String SERVER_DATABASE_FILE = "databaseFile";
     public static final String PROXY_PORT_KEY = "proxyPort";
     public static final String PROXY_REMOTE_PORT_KEY = "proxyRemotePort";
     public static final String PROXY_REMOTE_HOST_KEY = "proxyRemoteHost";
@@ -26,6 +27,12 @@ public class Main {
             "        -serverPort <port>           Specifies the HTTP, HTTPS, SOCKS and HTTP         " + System.getProperty("line.separator") +
             "                                     CONNECT port for proxy. Port unification          " + System.getProperty("line.separator") +
             "                                     supports for all protocols on the same port.      " + System.getProperty("line.separator") +
+            "                                                                                       " + System.getProperty("line.separator") +
+            "        -databaseFile <filename>     Specifies the database file name, where mock      " + System.getProperty("line.separator") +
+            "                                     server saves the expectations when exits.         " + System.getProperty("line.separator") +
+            "                                     If you start the server with a database file      " + System.getProperty("line.separator") +
+            "                                     you do not have to configure the expectations     " + System.getProperty("line.separator") +
+            "                                     every time.                                       " + System.getProperty("line.separator") +
             "                                                                                       " + System.getProperty("line.separator") +
             "        -proxyPort <port>            Specifies the HTTP and HTTPS port for the         " + System.getProperty("line.separator") +
             "                                     MockServer. Port unification is used to           " + System.getProperty("line.separator") +
@@ -80,7 +87,7 @@ public class Main {
 
         if (parsedArguments.size() > 0 && validateArguments(parsedArguments)) {
             if (parsedArguments.containsKey(SERVER_PORT_KEY)) {
-                mockServerBuilder.withHTTPPort(Integer.parseInt(parsedArguments.get(SERVER_PORT_KEY))).build();
+                mockServerBuilder.withHTTPPort(Integer.parseInt(parsedArguments.get(SERVER_PORT_KEY))).withDatabase(parsedArguments.get(SERVER_DATABASE_FILE)).build();
             }
             if (parsedArguments.containsKey(PROXY_PORT_KEY)) {
                 ProxyBuilder proxyBuilder = httpProxyBuilder.withLocalPort(Integer.parseInt(parsedArguments.get(PROXY_PORT_KEY)));
@@ -104,6 +111,7 @@ public class Main {
         validatePortArgument(parsedArguments, PROXY_PORT_KEY, errorMessages);
         validatePortArgument(parsedArguments, PROXY_REMOTE_PORT_KEY, errorMessages);
         validateHostnameArgument(parsedArguments, PROXY_REMOTE_HOST_KEY, errorMessages);
+        validateFileArgument(parsedArguments, SERVER_DATABASE_FILE, errorMessages);
 
         if (!errorMessages.isEmpty()) {
             int maxLengthMessage = 0;
@@ -120,6 +128,10 @@ public class Main {
             return false;
         }
         return true;
+    }
+
+    private static void validateFileArgument(Map<String, String> parsedArguments, String argumentKey, List<String> errorMessages) {
+        return;
     }
 
     private static void validatePortArgument(Map<String, String> parsedArguments, String argumentKey, List<String> errorMessages) {
@@ -143,10 +155,11 @@ public class Main {
             String argumentName = argumentsIterator.next();
             if (argumentsIterator.hasNext()) {
                 String argumentValue = argumentsIterator.next();
-                if (!parsePort(parsedArguments, SERVER_PORT_KEY, argumentName, argumentValue)
-                        && !parsePort(parsedArguments, PROXY_PORT_KEY, argumentName, argumentValue)
-                        && !parsePort(parsedArguments, PROXY_REMOTE_PORT_KEY, argumentName, argumentValue)
-                        && !("-" + PROXY_REMOTE_HOST_KEY).equalsIgnoreCase(argumentName)) {
+                if (!parseArgument(parsedArguments, SERVER_PORT_KEY, argumentName, argumentValue)
+                        && !parseArgument(parsedArguments, PROXY_PORT_KEY, argumentName, argumentValue)
+                        && !parseArgument(parsedArguments, PROXY_REMOTE_PORT_KEY, argumentName, argumentValue)
+                        && !("-" + PROXY_REMOTE_HOST_KEY).equalsIgnoreCase(argumentName)
+                        && !parseArgument(parsedArguments, SERVER_DATABASE_FILE, argumentName, argumentValue)) {
                     showUsage();
                     break;
                 }
@@ -161,7 +174,7 @@ public class Main {
         return parsedArguments;
     }
 
-    private static boolean parsePort(Map<String, String> parsedArguments, final String key, final String argumentName, final String argumentValue) {
+    private static boolean parseArgument(Map<String, String> parsedArguments, final String key, final String argumentName, final String argumentValue) {
         if (argumentName.equals("-" + key)) {
             parsedArguments.put(key, argumentValue);
             return true;

--- a/mockserver-netty/src/main/java/org/mockserver/mockserver/MockServer.java
+++ b/mockserver-netty/src/main/java/org/mockserver/mockserver/MockServer.java
@@ -1,5 +1,6 @@
 package org.mockserver.mockserver;
 
+import com.google.common.base.Joiner;
 import com.google.common.util.concurrent.SettableFuture;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
@@ -7,12 +8,22 @@ import io.netty.channel.*;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.util.AttributeKey;
+import org.apache.commons.lang3.exception.ExceptionContext;
+import org.mockserver.client.serialization.ExpectationSerializer;
 import org.mockserver.filters.LogFilter;
+import org.mockserver.mock.Expectation;
 import org.mockserver.mock.MockServerMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.*;
 import java.net.InetSocketAddress;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -24,7 +35,7 @@ public class MockServer {
     public static final AttributeKey<LogFilter> LOG_FILTER = AttributeKey.valueOf("SERVER_LOG_FILTER");
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     // mockserver
-    private final MockServerMatcher mockServerMatcher = new MockServerMatcher();
+    private final MockServerMatcher mockServerMatcher;
     private final LogFilter logFilter = new LogFilter();
     private final SettableFuture<Integer> hasStarted;
     // netty
@@ -32,17 +43,33 @@ public class MockServer {
     private final EventLoopGroup workerGroup = new NioEventLoopGroup();
     private Channel channel;
 
+    public MockServer(final Integer port) {
+        this(port, null);
+    }
+
     /**
      * Start the instance using the ports provided
      *
      * @param port the http port to use
      */
-    public MockServer(final Integer port) {
+    public MockServer(final Integer port, final String databaseFile) {
         if (port == null) {
             throw new IllegalArgumentException("You must specify a port");
         }
 
         hasStarted = SettableFuture.create();
+
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            public void run() {
+                logger.debug("Shutdown hook called.");
+                saveExpectations(mockServerMatcher.getExpectations(), databaseFile);
+            }
+        });
+
+        //
+        List<Expectation> expectations = loadExpectations(databaseFile);
+
+        this.mockServerMatcher = new MockServerMatcher(expectations);
 
         new Thread(new Runnable() {
             @Override
@@ -71,12 +98,15 @@ public class MockServer {
 
                     logger.info("MockServer started on port: {}", hasStarted.get());
 
+
                     channel.closeFuture().syncUninterruptibly();
+
                 } catch (Exception e) {
                     throw new RuntimeException("Exception while starting MockServer", e.getCause());
                 } finally {
                     bossGroup.shutdownGracefully(0, 1, TimeUnit.MILLISECONDS);
                     workerGroup.shutdownGracefully(0, 1, TimeUnit.MILLISECONDS);
+
                 }
             }
         }).start();
@@ -99,6 +129,56 @@ public class MockServer {
             logger.trace("Exception while stopping MockServer", ie);
         }
     }
+
+    public void saveExpectations(List<Expectation> expectations, String path) {
+
+        if (path == null) {
+            return;
+        }
+        // serialize expectations
+        ExpectationSerializer serializer = new ExpectationSerializer();
+        String serialized = serializer.serialize(expectations.toArray(new Expectation[expectations.size()]));
+
+        // Write expectations to a file. Do not use Java 7 features, like try-with-resources statement, to stay
+        // compatible with Java 6.
+        try {
+            logger.info("Try to save expectations to file {}", path);
+            com.google.common.io.Files.write(serialized, new File(path), Charset.forName("UTF8"));
+            logger.info("{} expectations are saved to file {}.", expectations.size(), path);
+        } catch (IOException e) {
+            logger.error("Unexpected IO error occurred, do not save expectations.", e);
+        }
+    }
+
+    public List<Expectation> loadExpectations(String path) {
+
+        if (path == null) {
+            logger.info("Do not use database file.");
+            return new ArrayList<Expectation>();
+        }
+
+        File f = new File(path);
+
+        //com.google.common.io.Files.read
+        ExpectationSerializer serializer = new ExpectationSerializer();
+        String deserialized = null;
+        try {
+            if (!f.exists()) {
+                logger.info("Create database file {}", path);
+                f.createNewFile();
+            }
+            List<String> lines = com.google.common.io.Files.readLines(new File(path), Charset.forName("UTF8"));
+            deserialized = Joiner.on("\n").join(lines);
+        } catch (IOException e) {
+            logger.error("Unable to load expectations from file.", e);
+            return new ArrayList<Expectation>();
+        }
+
+        Expectation[] expectations = serializer.deserializeArray(deserialized);
+        logger.info("{} epectation(s) successfully loaded from file {}.", expectations.length, path);
+        return new ArrayList<Expectation>(Arrays.asList(expectations));
+    }
+
 
     public boolean isRunning() {
         if (hasStarted.isDone()) {

--- a/mockserver-netty/src/main/java/org/mockserver/mockserver/MockServerBuilder.java
+++ b/mockserver-netty/src/main/java/org/mockserver/mockserver/MockServerBuilder.java
@@ -9,6 +9,8 @@ public class MockServerBuilder {
 
     private Integer port;
 
+    private String path;
+
     /**
      * Configure HTTP port for proxy, setting this value will ensure HTTP is supported
      *
@@ -24,10 +26,19 @@ public class MockServerBuilder {
         return this;
     }
 
+    public MockServerBuilder withDatabase(String path) {
+        if (path != null) {
+            this.path = path;
+        } else {
+            this.path = null;
+        }
+        return this;
+    }
+
     /**
      * Build an instance of the HttpProxy
      */
     public MockServer build() {
-        return new MockServer(port);
+        return new MockServer(port, path);
     }
 }


### PR DESCRIPTION
You can start mockserver with a new argument: -databaseFile.  It specifies the file name, where mockserver saves the expectations as JSON when exits, and from which the expections are loaded at startup. It was a little bit inconvenient to always reconfigure mockserver with a remote client, because my modifications were lost after the mockserver process exited. 