### PR TITLE
relaxed ruby client version constraints

### DIFF
--- a/mockserver-client-ruby/mockserver-client.gemspec
+++ b/mockserver-client-ruby/mockserver-client.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description = 'A Ruby Client for MockServer that enables easy mocking of any system you integrate with via HTTP or HTTPS (i.e. services, web sites, etc)'
 
   spec.required_ruby_version     = '>= 1.9'
-  spec.required_rubygems_version = '~> 2'
+  spec.required_rubygems_version = '~> 2.0'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(/^bin\//) { |f| File.basename(f) }
@@ -21,17 +21,17 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1'
-  spec.add_development_dependency 'rake', '~> 10.3.2'
-  spec.add_development_dependency 'rspec', '~> 3.0.0'
-  spec.add_development_dependency 'simplecov', '~> 0.8.2'
+  spec.add_development_dependency 'rake', '~> 10.3'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'simplecov', '~> 0.8'
   spec.add_development_dependency 'webmock', '~> 1.18'
-  spec.add_development_dependency 'rubocop', '~> 0.23.0'
+  spec.add_development_dependency 'rubocop', '~> 0.23'
 
   spec.add_dependency 'hashie', '~> 3.0'
-  spec.add_dependency 'json', '~> 1.8.1'
-  spec.add_dependency 'activesupport', '~> 4.2.0'
-  spec.add_dependency 'rest-client', '~> 1.7.2'
+  spec.add_dependency 'json', '~> 1.8'
+  spec.add_dependency 'activesupport', '~> 4.1'
+  spec.add_dependency 'rest-client', '~> 1.7'
   spec.add_dependency 'logging_factory', '~> 0.0.2'
-  spec.add_dependency 'thor', '~> 0.19.1'
-  spec.add_dependency 'colorize', '~> 0.7.0'
+  spec.add_dependency 'thor', '~> 0.19'
+  spec.add_dependency 'colorize', '~> 0.7'
 end


### PR DESCRIPTION
I relaxed the version constraints on the gemspec dependencies. Ruby libraries usually pin the version requirements to the major version (`~> 3.1`) since pinning on the minor version is usually too restrictive.

I also downgraded the activesupport from `~> 4.2.0` to `~> 4.1` since this prevents the library to work with Rails versions prior to 4.2, and this gem doesn't seem to require any of the newer features of activesupport 4.2 .