### PR TITLE
Replace Joda Time usage with plain java.util.Date to resolve implicit dependency

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/client/serialization/model/TimeToLiveDTO.java
+++ b/mockserver-core/src/main/java/org/mockserver/client/serialization/model/TimeToLiveDTO.java
@@ -1,9 +1,6 @@
 package org.mockserver.client.serialization.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.joda.time.DateTime;
 import org.mockserver.matchers.TimeToLive;
-import org.mockserver.matchers.Times;
 import org.mockserver.model.ObjectWithReflectiveEqualsHashCodeToString;
 
 import java.util.concurrent.TimeUnit;

--- a/mockserver-core/src/main/java/org/mockserver/matchers/TimeToLive.java
+++ b/mockserver-core/src/main/java/org/mockserver/matchers/TimeToLive.java
@@ -1,8 +1,8 @@
 package org.mockserver.matchers;
 
-import org.joda.time.DateTime;
 import org.mockserver.model.ObjectWithReflectiveEqualsHashCodeToString;
 
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -13,17 +13,17 @@ public class TimeToLive extends ObjectWithReflectiveEqualsHashCodeToString {
     private final TimeUnit timeUnit;
     private final Long timeToLive;
     private final boolean unlimited;
-    private final DateTime createdDate;
-    private DateTime endDate;
+    private final Date createdDate;
+    private Date endDate;
 
     private TimeToLive(TimeUnit timeUnit, Long timeToLive, boolean unlimited) {
         addFieldsExcludedFromEqualsAndHashCode("createdDate", "endDate");
         this.timeUnit = timeUnit;
         this.timeToLive = timeToLive;
         this.unlimited = unlimited;
-        createdDate = DateTime.now();
+        createdDate = new Date();
         if (!unlimited) {
-            endDate = DateTime.now().plus(timeUnit.toMillis(timeToLive));
+            endDate = new Date(System.currentTimeMillis() + timeUnit.toMillis(timeToLive));
         }
     }
 
@@ -48,13 +48,17 @@ public class TimeToLive extends ObjectWithReflectiveEqualsHashCodeToString {
     }
 
     public boolean stillAlive() {
-        if (unlimited || endDate.isAfterNow()) {
+        if (unlimited || isAfterNow(endDate)) {
             return true;
         } else {
             if (logger.isTraceEnabled()) {
-                logger.trace("Remaining time is " + (endDate.getMillis() - createdDate.getMillis()) + "ms");
+                logger.trace("Remaining time is " + (endDate.getTime() - createdDate.getTime()) + "ms");
             }
             return false;
         }
+    }
+
+    private boolean isAfterNow(Date date) {
+        return date.getTime() > System.currentTimeMillis();
     }
 }


### PR DESCRIPTION
mockserver-core has a dependency to joda-time in its org.mockserver.matchers.TimeToLive class. However the dependency to joda-time is not declared explicitely in the pom.xml but is only included in the module as a transitive dependency of com.github.fge:json-schema-validator.

One way to solve this problem would be to declare joda-time in the Maven poms. However, as there is only a single class and a very simple use case for which joda-time is used I recommend to not depend on Joda Time at all. This prevents potential version clashes if mockserver is used in JUnit tests. In one project we're pinned to Joda Time 1.x which doesn't provide the DateTime.now() method and thus breaks  mockserver.