### PR TITLE
#191 VerificationTimes supports lower and upper bounds

### DIFF
--- a/mockserver-core/pom.xml
+++ b/mockserver-core/pom.xml
@@ -81,6 +81,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.skyscreamer</groupId>
             <artifactId>jsonassert</artifactId>
         </dependency>

--- a/mockserver-core/src/main/java/org/mockserver/client/serialization/ObjectMapperFactory.java
+++ b/mockserver-core/src/main/java/org/mockserver/client/serialization/ObjectMapperFactory.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import org.mockserver.client.serialization.deserializers.body.BodyDTODeserializer;
 import org.mockserver.client.serialization.deserializers.string.NottableStringDeserializer;
 import org.mockserver.client.serialization.model.*;
@@ -51,6 +52,7 @@ public class ObjectMapperFactory {
         Module gameServerModule = new Module();
         objectMapper.registerModule(gameServerModule);
 
+        objectMapper.registerModule(new GuavaModule());
         return objectMapper;
     }
 

--- a/mockserver-core/src/main/java/org/mockserver/client/serialization/model/VerificationTimesDTO.java
+++ b/mockserver-core/src/main/java/org/mockserver/client/serialization/model/VerificationTimesDTO.java
@@ -8,32 +8,40 @@ import org.mockserver.verify.VerificationTimes;
  */
 public class VerificationTimesDTO extends ObjectWithReflectiveEqualsHashCodeToString {
 
-    private int count;
-    private boolean exact;
+    private int lowerBound;
+    private int upperBound;
 
     public VerificationTimesDTO(VerificationTimes times) {
-        count = times.getCount();
-        exact = times.isExact();
+        lowerBound = times.getLowerBound().or(-1);
+        upperBound = times.getUpperBound().or(-1);
     }
 
+    @SuppressWarnings("unused")
     public VerificationTimesDTO() {
     }
 
     public VerificationTimes buildObject() {
-        if (!exact) {
-            return VerificationTimes.atLeast(count);
-        } else if (count == 1) {
-            return VerificationTimes.once();
+        if (lowerBound >= 0) {
+            if (upperBound >= 0) {
+                return VerificationTimes.between(lowerBound, upperBound);
+            } else {
+                return VerificationTimes.atLeast(lowerBound);
+            }
         } else {
-            return VerificationTimes.exactly(count);
+            if (upperBound >= 0) {
+                return VerificationTimes.atMost(upperBound);
+            } else {
+                // Should never happen, VerificationTimes doesn't allow this invariant.
+                throw new IllegalStateException("Neither lower nor upper bound is defined");
+            }
         }
     }
 
-    public int getCount() {
-        return count;
+    public int getLowerBound() {
+        return lowerBound;
     }
 
-    public boolean isExact() {
-        return exact;
+    public int getUpperBound() {
+        return upperBound;
     }
 }

--- a/mockserver-core/src/main/java/org/mockserver/filters/LogFilter.java
+++ b/mockserver-core/src/main/java/org/mockserver/filters/LogFilter.java
@@ -157,17 +157,7 @@ public class LogFilter implements ResponseFilter, RequestFilter {
                 }
             }
 
-            boolean verified = true;
-
-            if (verification.getTimes().getCount() != 0 && matchingRequests.isEmpty()) {
-                verified = false;
-            } else if (verification.getTimes().isExact() && matchingRequests.size() != verification.getTimes().getCount()) {
-                verified = false;
-            } else if (matchingRequests.size() < verification.getTimes().getCount()) {
-                verified = false;
-            }
-
-            if (!verified) {
+            if (!verification.getTimes().matchesActualCount(matchingRequests.size())) {
                 HttpRequest[] allRequestsArray = requestLog.toArray(new HttpRequest[requestLog.size()]);
                 String serializedRequestToBeVerified = httpRequestSerializer.serialize(verification.getHttpRequest());
                 String serializedAllRequestInLog = allRequestsArray.length == 1 ? httpRequestSerializer.serialize(allRequestsArray[0]) : httpRequestSerializer.serialize(allRequestsArray);

--- a/mockserver-core/src/main/java/org/mockserver/verify/VerificationTimes.java
+++ b/mockserver-core/src/main/java/org/mockserver/verify/VerificationTimes.java
@@ -1,5 +1,8 @@
 package org.mockserver.verify;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import org.mockserver.model.ObjectWithReflectiveEqualsHashCodeToString;
 
 /**
@@ -7,46 +10,106 @@ import org.mockserver.model.ObjectWithReflectiveEqualsHashCodeToString;
  */
 public class VerificationTimes extends ObjectWithReflectiveEqualsHashCodeToString {
 
-    private final int count;
-    private final boolean exact;
+    private final Optional<Integer> lowerBound;
+    private final Optional<Integer> upperBound;
 
-    private VerificationTimes(int count, boolean exact) {
-        this.count = count;
-        this.exact = exact;
+    private VerificationTimes(Optional<Integer> lowerBound, Optional<Integer> upperBound) {
+        this.lowerBound = lowerBound;
+        this.upperBound = upperBound;
+    }
+
+    public Optional<Integer> getLowerBound() {
+        return lowerBound;
+    }
+
+    public Optional<Integer> getUpperBound() {
+        return upperBound;
+    }
+
+    @JsonIgnore
+    public Optional<Integer> getExactCount() {
+        if (lowerBound.equals(upperBound)) {
+            return lowerBound;
+        } else {
+            return Optional.absent();
+        }
+    }
+
+    public static VerificationTimes between(int lowerBound, int upperBound) {
+        Preconditions.checkArgument(lowerBound >= 0, "Negative lower bound");
+        Preconditions.checkArgument(upperBound >= 0, "Negative upper bound");
+        Preconditions.checkArgument(upperBound >= lowerBound, "Upper bound is smaller than lower bound");
+        return new VerificationTimes(Optional.of(lowerBound), Optional.of(upperBound));
+    }
+
+    public static VerificationTimes never() {
+        return exactly(0);
     }
 
     public static VerificationTimes once() {
-        return new VerificationTimes(1, true);
+        return exactly(1);
     }
 
     public static VerificationTimes exactly(int count) {
-        return new VerificationTimes(count, true);
+        return between(count, count);
     }
 
     public static VerificationTimes atLeast(int count) {
-        return new VerificationTimes(count, false);
+        Preconditions.checkArgument(count >= 0, "Negative count");
+        Preconditions.checkArgument(count != 0, "Count is zero");
+        return new VerificationTimes(Optional.of(count), Optional.<Integer>absent());
     }
 
-    public int getCount() {
-        return count;
+    public static VerificationTimes atMost(int count) {
+        Preconditions.checkArgument(count >= 0, "Negative count");
+        return new VerificationTimes(Optional.<Integer>absent(), Optional.of(count));
     }
 
-    public boolean isExact() {
-        return exact;
+    public boolean matchesActualCount(Integer count) {
+        return (!lowerBound.isPresent() || lowerBound.get() <= count) &&
+                (!upperBound.isPresent() || upperBound.get() >= count);
     }
-
+    
     public String toString() {
-        String string = "";
-        if (exact) {
-            string += "exactly ";
-        } else {
-            string += "at least ";
+        StringBuilder sb = new StringBuilder();
+        if (getExactCount().isPresent()) {
+          int count = getExactCount().get();
+          if (count == 1) {
+            sb.append("exactly once");
+          } else if (count == 0) {
+            sb.append("never");
+          } else {
+            sb.append("exactly ");
+            sb.append(count);
+            sb.append(" times");
+          }
+        } else if (lowerBound.isPresent() && upperBound.isPresent()) {
+            sb.append("between ");
+            sb.append(lowerBound.get());
+            sb.append(" and ");
+            sb.append(upperBound.get());
+            sb.append(" times");
+        } else if (lowerBound.isPresent()) {
+            sb.append("at least ");
+            if (lowerBound.get() == 1) {
+                sb.append("once");
+            } else {
+                sb.append(lowerBound.get());
+                sb.append(" times");
+            }
+        } else if (upperBound.isPresent()) {
+            if (upperBound.get() == 0) {
+                sb.append("never");
+            } else {
+                sb.append("at most ");
+                if (upperBound.get() == 1) {
+                    sb.append("once");
+                } else {
+                    sb.append(upperBound.get());
+                    sb.append(" times");
+                }
+            }
         }
-        if (count == 1) {
-            string += "once";
-        } else {
-            string += count + " times";
-        }
-        return string;
+        return sb.toString();
     }
 }

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/VerificationSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/VerificationSerializerTest.java
@@ -102,12 +102,12 @@ public class VerificationSerializerTest {
     public void serializeHandlesException() throws IOException {
         // given
         thrown.expect(RuntimeException.class);
-        thrown.expectMessage("Exception while serializing verification to JSON with value {" + System.getProperty("line.separator") +
-                "  \"httpRequest\" : { }," + System.getProperty("line.separator") +
-                "  \"times\" : {" + System.getProperty("line.separator") +
-                "    \"count\" : 1," + System.getProperty("line.separator") +
-                "    \"exact\" : false" + System.getProperty("line.separator") +
-                "  }" + System.getProperty("line.separator") +
+        String ln = System.getProperty("line.separator");
+        thrown.expectMessage("Exception while serializing verification to JSON with value {" + ln +
+                "  \"httpRequest\" : { }," + ln +
+                "  \"times\" : {" + ln +
+                "    \"lowerBound\" : 1" + ln +
+                "  }" + ln +
                 "}");
         // and
         when(objectMapper.writerWithDefaultPrettyPrinter()).thenReturn(objectWriter);

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/model/VerificationTimesDTOTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/model/VerificationTimesDTOTest.java
@@ -3,43 +3,42 @@ package org.mockserver.client.serialization.model;
 import org.junit.Test;
 import org.mockserver.verify.VerificationTimes;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.mockserver.verify.VerificationTimes.*;
 
 public class VerificationTimesDTOTest {
 
     @Test
-    public void shouldReturnValuesSetInConstructor() {
-        // when
-        VerificationTimesDTO times = new VerificationTimesDTO(VerificationTimes.exactly(5));
-
-        // then
-        assertThat(times.getCount(), is(5));
-        assertThat(times.isExact(), is(true));
+    public void shouldBuildObject_once() {
+        assertValidVerificationTimesBuilt(once());
     }
 
     @Test
-    public void shouldBuildCorrectObject() {
-        // when
-        VerificationTimes times = new VerificationTimesDTO(VerificationTimes.once()).buildObject();
-
-        // then
-        assertThat(times.getCount(), is(1));
-        assertThat(times.isExact(), is(true));
-
-        // when
-        times = new VerificationTimesDTO(VerificationTimes.exactly(3)).buildObject();
-
-        // then
-        assertThat(times.getCount(), is(3));
-        assertThat(times.isExact(), is(true));
-
-        // when
-        times = new VerificationTimesDTO(VerificationTimes.atLeast(3)).buildObject();
-
-        // then
-        assertThat(times.getCount(), is(3));
-        assertThat(times.isExact(), is(false));
+    public void shouldBuildObject_never() {
+        assertValidVerificationTimesBuilt(never());
     }
 
+    @Test
+    public void shouldBuildObject_exactly() {
+        assertValidVerificationTimesBuilt(exactly(42));
+    }
+
+    @Test
+    public void shouldBuildObject_atLeast() {
+        assertValidVerificationTimesBuilt(atLeast(42));
+    }
+
+    @Test
+    public void shouldBuildObject_atMost() {
+        assertValidVerificationTimesBuilt(atMost(42));
+    }
+
+    @Test
+    public void shouldBuildObject_between() {
+        assertValidVerificationTimesBuilt(between(41, 42));
+    }
+
+    private void assertValidVerificationTimesBuilt(VerificationTimes originalTimes) {
+        assertEquals(new VerificationTimesDTO(originalTimes).buildObject(), originalTimes);
+    }
 }

--- a/mockserver-core/src/test/java/org/mockserver/filters/LogFilterVerificationTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/filters/LogFilterVerificationTest.java
@@ -86,29 +86,6 @@ public class LogFilterVerificationTest {
     }
 
     @Test
-    public void shouldPassVerificationWithAtLeastZeroTimes() {
-        // given
-        HttpRequest httpRequest = new HttpRequest().withPath("some_path");
-        HttpRequest otherHttpRequest = new HttpRequest().withPath("some_other_path");
-        LogFilter logFilter = new LogFilter();
-
-        // when
-        logFilter.onRequest(httpRequest);
-        logFilter.onRequest(otherHttpRequest);
-        logFilter.onRequest(httpRequest);
-
-        // then
-        assertThat(logFilter.verify(
-                        new Verification()
-                                .withRequest(
-                                        new HttpRequest().withPath("some_non_matching_path")
-                                )
-                                .withTimes(atLeast(0))
-                ),
-                is(""));
-    }
-
-    @Test
     public void shouldPassVerificationWithExactlyTwoTimes() {
         // given
         HttpRequest httpRequest = new HttpRequest().withPath("some_path");
@@ -298,7 +275,7 @@ public class LogFilterVerificationTest {
                                 )
                                 .withTimes(exactly(0))
                 ),
-                is("Request not found exactly 0 times, expected:<{" + System.getProperty("line.separator") +
+                is("Request not found never, expected:<{" + System.getProperty("line.separator") +
                         "  \"path\" : \"some_other_path\"" + System.getProperty("line.separator") +
                         "}> but was:<[ {" + System.getProperty("line.separator") +
                         "  \"path\" : \"some_path\"" + System.getProperty("line.separator") +
@@ -324,6 +301,6 @@ public class LogFilterVerificationTest {
                                 .withRequest(request())
                                 .withTimes(exactly(0))
                 ),
-                is("Request not found exactly 0 times, expected:<{ }> but was:<{ }>"));
+                is("Request not found never, expected:<{ }> but was:<{ }>"));
     }
 }

--- a/mockserver-core/src/test/java/org/mockserver/verify/VerificationTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/verify/VerificationTest.java
@@ -5,6 +5,7 @@ import org.mockserver.model.HttpRequest;
 
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.verify.VerificationTimes.atLeast;
 
@@ -27,4 +28,18 @@ public class VerificationTest {
         assertThat(verification.getTimes(), sameInstance(times));
     }
 
+    @Test
+    public void shouldSerializeToJsonString() throws Exception {
+        String nl = System.getProperty("line.separator");
+        assertEquals(
+            "{" + nl +
+            "  \"httpRequest\" : { }," + nl +
+            "  \"times\" : {" + nl +
+            "    \"lowerBound\" : 1" + nl +
+            "  }" + nl +
+            "}",
+            new Verification().toString()
+        );
+
+    }
 }

--- a/mockserver-core/src/test/java/org/mockserver/verify/VerificationTimesTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/verify/VerificationTimesTest.java
@@ -1,5 +1,6 @@
 package org.mockserver.verify;
 
+import com.google.common.base.Optional;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -12,44 +13,140 @@ import static org.mockserver.verify.VerificationTimes.*;
 public class VerificationTimesTest {
 
     @Test
+    public void shouldCreateCorrectObjectForBetween() {
+        VerificationTimes times = between(2, 3);
+
+        assertThat(times.getExactCount().isPresent(), is(false));
+        assertThat(times.getUpperBound(), is(Optional.of(3)));
+        assertThat(times.getLowerBound(), is(Optional.of(2)));
+    }
+
+    @Test
     public void shouldCreateCorrectObjectForAtLeast() {
-        // when
         VerificationTimes times = atLeast(2);
 
-        // then
-        assertThat(times.isExact(), is(false));
-        assertThat(times.getCount(), is(2));
+        assertThat(times.getExactCount().isPresent(), is(false));
+        assertThat(times.getUpperBound().isPresent(), is(false));
+        assertThat(times.getLowerBound(), is(Optional.of(2)));
+    }
+
+    @Test
+    public void shouldCreateCorrectObjectForAtMost() {
+        VerificationTimes times = atMost(2);
+
+        assertThat(times.getExactCount().isPresent(), is(false));
+        assertThat(times.getUpperBound(), is(Optional.of(2)));
+        assertThat(times.getLowerBound().isPresent(), is(false));
     }
 
     @Test
     public void shouldCreateCorrectObjectForExactly() {
-        // when
         VerificationTimes times = exactly(2);
 
-        // then
-        assertThat(times.isExact(), is(true));
-        assertThat(times.getCount(), is(2));
+        assertThat(times.getExactCount(), is(Optional.of(2)));
+        assertThat(times.getUpperBound(), is(Optional.of(2)));
+        assertThat(times.getLowerBound(), is(Optional.of(2)));
     }
 
     @Test
     public void shouldCreateCorrectObjectForOnce() {
-        // when
         VerificationTimes times = once();
 
-        // then
-        assertThat(times.isExact(), is(true));
-        assertThat(times.getCount(), is(1));
+        assertThat(times.getExactCount(), is(Optional.of(1)));
+        assertThat(times.getUpperBound(), is(Optional.of(1)));
+        assertThat(times.getLowerBound(), is(Optional.of(1)));
+    }
+
+    @Test
+    public void shouldCreateCorrectObjectForNever() {
+        VerificationTimes times = never();
+
+        assertThat(times.getExactCount(), is(Optional.of(0)));
+        assertThat(times.getUpperBound(), is(Optional.of(0)));
+        assertThat(times.getLowerBound(), is(Optional.of(0)));
+    }
+
+    @Test
+    public void shouldMatchActualCount_between() {
+        VerificationTimes times = between(3, 5);
+
+        assertThat(times.matchesActualCount(2), is(false));
+        assertThat(times.matchesActualCount(3), is(true));
+        assertThat(times.matchesActualCount(4), is(true));
+        assertThat(times.matchesActualCount(5), is(true));
+        assertThat(times.matchesActualCount(6), is(false));
+    }
+
+    @Test
+    public void shouldMatchActualCount_exactly() {
+        VerificationTimes times = exactly(42);
+
+        assertThat(times.matchesActualCount(41), is(false));
+        assertThat(times.matchesActualCount(42), is(true));
+        assertThat(times.matchesActualCount(43), is(false));
+    }
+
+    @Test
+    public void shouldMatchActualCount_never() {
+        VerificationTimes times = never();
+
+        assertThat(times.matchesActualCount(1), is(false));
+        assertThat(times.matchesActualCount(42), is(false));
+        assertThat(times.matchesActualCount(0), is(true));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowNegativeCountForExactly() {
+        exactly(-42);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowNegativeCountForBetween_Lower() {
+        between(-42, 42);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowNegativeCountForBetween_Upper() {
+        between(42, -42);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowBetweenInvalidRange() {
+        between(43, 41);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowNegativeCountForAtMost() {
+        atLeast(-42);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowNegativeCountForAtLeast() {
+        atLeast(-42);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowZeroCountForAtLeast() {
+        atLeast(0);
     }
 
     @Test
     public void shouldGenerateCorrectToString() {
-        // then
         assertThat(once().toString(), is("exactly once"));
-        assertThat(atLeast(0).toString(), is("at least 0 times"));
+        assertThat(never().toString(), is("never"));
+        
         assertThat(atLeast(1).toString(), is("at least once"));
         assertThat(atLeast(2).toString(), is("at least 2 times"));
-        assertThat(exactly(0).toString(), is("exactly 0 times"));
+        
+        assertThat(atMost(0).toString(), is("never"));
+        assertThat(atMost(1).toString(), is("at most once"));
+        assertThat(atMost(2).toString(), is("at most 2 times"));
+        
+        assertThat(exactly(0).toString(), is("never"));
         assertThat(exactly(1).toString(), is("exactly once"));
         assertThat(exactly(2).toString(), is("exactly 2 times"));
+
+        assertThat(between(41, 43).toString(), is("between 41 and 43 times"));
+        assertThat(between(0, 1).toString(), is("between 0 and 1 times"));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <!-- tomcat version &gt; 7.0.56 causes SSL to fail -->
         <tomcat.version>7.0.56</tomcat.version>
         <jackson.version>2.5.3</jackson.version>
+        <jackson.datatype.guava.version>2.4.0</jackson.datatype.guava.version>
         <netty.version>4.0.31.Final</netty.version>
         <boucycastle.verion>1.52</boucycastle.verion>
         <spring.version>4.1.6.RELEASE</spring.version>
@@ -268,6 +269,11 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-guava</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
I have changed `VerificationTimes` to support optional lower and upper bound, so instead of
```
Integer count,
Boolean exact
```

it has now
```
Optional<Integer> lowerBound,
Optional<Integer> upperBound
```
which makes it possible to express all expectations, including `atMost(count)`:

**never()** == **exactly(0)**
```
Optional<Integer> lowerBound = Optional.of(0);
Optional<Integer> upperBound = Optional.of(0);
```

**once()**== **exactly(1)**
```
Optional<Integer> lowerBound = Optional.of(1);
Optional<Integer> upperBound = Optional.of(1);
```

**exactly(42)**
```
Optional<Integer> lowerBound = Optional.of(42);
Optional<Integer> upperBound = Optional.of(42);
```

**atLeast(42)**
```
Optional<Integer> lowerBound = Optional.of(42);
Optional<Integer> upperBound = Optional.absent();
```

**atMost(42)**
```
Optional<Integer> lowerBound = Optional.absent();
Optional<Integer> upperBound = Optional.of(42);
```