### PR TITLE
Ensure ca/client cert serial number positive

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/socket/KeyStoreFactory.java
+++ b/mockserver-core/src/main/java/org/mockserver/socket/KeyStoreFactory.java
@@ -124,7 +124,7 @@ public class KeyStoreFactory {
         //
         // serial
         //
-        BigInteger serial = BigInteger.valueOf(new Random().nextInt());
+        BigInteger serial = BigInteger.valueOf(new Random().nextInt(Integer.MAX_VALUE));
 
         //
         // create the certificate - version 3
@@ -167,7 +167,7 @@ public class KeyStoreFactory {
         //
         // serial
         //
-        BigInteger serial = BigInteger.valueOf(new Random().nextInt());
+        BigInteger serial = BigInteger.valueOf(new Random().nextInt(Integer.MAX_VALUE));
 
         //
         // create the certificate - version 3

--- a/mockserver-core/src/test/java/org/mockserver/socket/KeyStoreFactoryTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/socket/KeyStoreFactoryTest.java
@@ -1,0 +1,54 @@
+package org.mockserver.socket;
+
+import org.junit.Test;
+import org.junit.Before;
+import static org.junit.Assert.assertTrue;
+
+import java.security.cert.X509Certificate;
+import java.security.KeyPair;
+import java.security.PublicKey;
+import java.security.PrivateKey;
+import java.math.BigInteger;
+
+import java.lang.Exception;
+
+/**
+ * @author jnormington
+ */
+public class KeyStoreFactoryTest {
+
+    KeyStoreFactory keyStoreFactory;
+    KeyPair caKeyPair;
+
+    @Before
+    public void setUp() throws Exception {
+        this.keyStoreFactory = new KeyStoreFactory();
+        this.caKeyPair = this.keyStoreFactory.generateKeyPair(1024);
+    }
+
+    @Test
+    public void shouldCreateCACertWithPositiveSerialNumber()  throws Exception {
+        X509Certificate newCaCert = this.keyStoreFactory.createCACert(caKeyPair.getPublic(), caKeyPair.getPrivate());
+        assertTrue("The cacert serial number is non-negative",
+            newCaCert.getSerialNumber().compareTo(BigInteger.ZERO) > 0);
+    }
+
+    @Test
+    public void shouldCreateClientCertWithPositiveSerialNumber()  throws Exception {
+        X509Certificate caCert = this.keyStoreFactory.createCACert(caKeyPair.getPublic(), caKeyPair.getPrivate());
+        KeyPair clientKeyPair = this.keyStoreFactory.generateKeyPair(1024);
+
+        X509Certificate clientCert = this.keyStoreFactory.createClientCert(
+            clientKeyPair.getPublic(),
+            caCert,
+            this.caKeyPair.getPrivate(),
+            this.caKeyPair.getPublic(),
+            "example.com",
+            new String[]{ "www.example.com"},
+            null
+        );
+
+        assertTrue("The client cert serial number is non-negative",
+            clientCert.getSerialNumber().compareTo(BigInteger.ZERO) > 0);
+    }
+}


### PR DESCRIPTION
 - This caused bad certification validation errors with go 1.4
   do to adhering to the RFC3280 where the serial number should
   always be non-negative.
 - This change ensures that we pass Integer.MAX_VALUE to Random#nextInt(val)
   so that a positive number from 0 to val is generated as per the java docs