### PR TITLE
Only transform the supplied request body type if type is BINARY

### DIFF
--- a/mockserver-client-ruby/lib/mockserver/model/request.rb
+++ b/mockserver-client-ruby/lib/mockserver/model/request.rb
@@ -32,9 +32,12 @@ module MockServer::Model
     property :cookies, default: Cookies.new([])
     property :headers, default: Headers.new([])
     property :body, transform_with: (lambda do |body|
-      is_base_64_body = body && body.type == :BINARY
-      body_value = is_base_64_body ? Base64.decode64(body.value) : body.value
-      Body.new(type: :STRING, value: body_value)
+      if body && body.type.to_s == 'BINARY'
+        body.type = :STRING
+        body.value = Base64.decode64(body.value)
+      end
+
+      body
     end)
 
     coerce_key :method, HTTPMethod


### PR DESCRIPTION
 - There were two bugs with the transformation.
 
Firstly it always altered the body type to String causing issues for other types such as REGEX.
Secondly the transformation for BINARY didn't actually happen because we was comparing BodyType with a symbol which was failing miserably and not actually transforming the body value.