### PR TITLE
Fix java command arguments in docker run script

### DIFF
--- a/docker/run_mockserver.sh
+++ b/docker/run_mockserver.sh
@@ -96,7 +96,7 @@ fi
 
 validateArgument $LOG_LEVEL "OFF ERROR WARN INFO DEBUG TRACE ALL." "Invalid value '$LOG_LEVEL' for 'logLevel'"
 
-COMMAND_LINE_OPTS="-Djava.library.path=$MOCKSERVER_HOME/libtcnative-1.so.0.1.27"
+COMMAND_LINE_OPTS=""
 
 if [ -n "$serverPort" ]
 then
@@ -120,4 +120,4 @@ then
     MOCKSERVER_HOME="/opt/mockserver"
 fi
 
-runCommand "java -Dfile.encoding=UTF-8 -Dmockserver.logLevel=$LOG_LEVEL -cp $MOCKSERVER_HOME/mockserver-netty-jar-with-dependencies.jar:$MOCKSERVER_HOME/tomcat-native-1.1.27.jar org.mockserver.cli.Main$COMMAND_LINE_OPTS"
+runCommand "java -Dfile.encoding=UTF-8 -Dmockserver.logLevel=$LOG_LEVEL -Djava.library.path=$MOCKSERVER_HOME/libtcnative-1.so.0.1.27 -cp $MOCKSERVER_HOME/mockserver-netty-jar-with-dependencies.jar:$MOCKSERVER_HOME/tomcat-native-1.1.27.jar org.mockserver.cli.Main$COMMAND_LINE_OPTS"


### PR DESCRIPTION
~~Since commit 905a71d the COMMAND_LINE_OPTS variable doesn't have a
leading space. This results in an error: "Could not find or load main class
org.mockserver.cli.Main-Djava.library.path=.libtcnative-1.so.0.1.27".~~

Java system property java.library.path should not be a part of
COMMAND_LINE_OPTS string, because system properties must be specified
before the main class name (see java command usage).