### PR TITLE
Added the ability to get Expectations back from retrieve for a proxy

### DIFF
--- a/mockserver-core/src/test/java/org/mockserver/filters/RequestResponseLogFilterTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/filters/RequestResponseLogFilterTest.java
@@ -1,16 +1,17 @@
 package org.mockserver.filters;
 
 import org.junit.Test;
-import org.mockserver.model.Cookie;
-import org.mockserver.model.Header;
-import org.mockserver.model.HttpRequest;
-import org.mockserver.model.HttpResponse;
+import org.mockserver.client.serialization.ExpectationSerializer;
+import org.mockserver.mock.Expectation;
+import org.mockserver.model.*;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.notFoundResponse;
 import static org.mockserver.model.HttpResponse.response;
@@ -73,6 +74,46 @@ public class RequestResponseLogFilterTest {
         assertEquals(requestResponseLogFilter.httpResponses(request()), Arrays.asList(response("some_body"), response("some_body"), notFoundResponse(), notFoundResponse(), response("some_other_body")));
         assertEquals(requestResponseLogFilter.httpResponses(request("some_path")), Arrays.asList(response("some_body"), response("some_body"), notFoundResponse(), notFoundResponse()));
         assertEquals(requestResponseLogFilter.httpResponses(request("some_other_path")), Arrays.asList(response("some_other_body")));
+    }
+
+    @Test
+    public void shouldReturnExpectations(){
+        // given
+        RequestResponseLogFilter requestResponseLogFilter = new RequestResponseLogFilter();
+
+        //and - called for responses
+        requestResponseLogFilter.onResponse(request("some_path"), response("some_body"));
+        requestResponseLogFilter.onResponse(request("some_other_path"), response("some_other_body"));
+        requestResponseLogFilter.onResponse(request("some_path"), response("some_body"));
+        requestResponseLogFilter.onResponse(request("some_path"), null);
+        requestResponseLogFilter.onResponse(request("some_path"), notFoundResponse());
+        //and - non matching request
+        HttpRequest should_not_match = request("should_not_match");
+        should_not_match.setNot(true);
+        requestResponseLogFilter.onResponse(should_not_match, response("should_not_match_body"));
+
+        //when
+        Expectation[] expectations = requestResponseLogFilter.getExpectations(request());
+
+        System.out.println("new ExpectationSerializer().serialize(expectations) = " + new ExpectationSerializer().serialize(expectations));
+        //then
+        assertEquals("should match only 5", 5, expectations.length);
+        List<HttpResponse> somePath = new ArrayList<HttpResponse>();
+        List<HttpResponse> someOtherPath = new ArrayList<HttpResponse>();
+        for (Expectation expectation : expectations) {
+            HttpRequest httpRequest = expectation.getHttpRequest();
+            HttpResponse httpResponse = expectation.getHttpResponse();
+            String httpRequestPath =  httpRequest.getPath().getValue();
+            if("some_path".equals(httpRequestPath)){
+                somePath.add(httpResponse);
+            }else if("some_other_path".equals(httpRequestPath)){
+                someOtherPath.add(httpResponse);
+            }else {
+                fail("http request path should only be some_path or some_other_path");
+            }
+        }
+        assertEquals(somePath, Arrays.asList(response("some_body"), response("some_body"), notFoundResponse(), notFoundResponse()));
+        assertEquals(someOtherPath,Arrays.asList(response("some_other_body")));
     }
 
     @Test

--- a/mockserver-netty/src/main/java/org/mockserver/proxy/http/HttpProxyHandler.java
+++ b/mockserver-netty/src/main/java/org/mockserver/proxy/http/HttpProxyHandler.java
@@ -16,6 +16,7 @@ import org.mockserver.filters.RequestLogFilter;
 import org.mockserver.filters.RequestResponseLogFilter;
 import org.mockserver.logging.LogFormatter;
 import org.mockserver.mappers.ContentTypeMapper;
+import org.mockserver.mock.Expectation;
 import org.mockserver.model.Body;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
@@ -95,6 +96,7 @@ public class HttpProxyHandler extends SimpleChannelInboundHandler<HttpRequest> {
 
                 org.mockserver.model.HttpRequest httpRequest = httpRequestSerializer.deserialize(request.getBodyAsString());
                 requestLogFilter.clear(httpRequest);
+                requestResponseLogFilter.clear(httpRequest);
                 logFormatter.infoLog("clearing expectations and request logs that match:{}", httpRequest);
                 writeResponse(ctx, request, HttpResponseStatus.ACCEPTED);
 
@@ -110,9 +112,13 @@ public class HttpProxyHandler extends SimpleChannelInboundHandler<HttpRequest> {
                 writeResponse(ctx, request, HttpResponseStatus.ACCEPTED);
 
             } else if (request.matches("PUT", "/retrieve")) {
-
-                HttpRequest[] requests = requestLogFilter.retrieve(httpRequestSerializer.deserialize(request.getBodyAsString()));
-                writeResponse(ctx, request, HttpResponseStatus.OK, httpRequestSerializer.serialize(requests), "application/json");
+                if (request.hasQueryStringParameter("type", "expectation")) {
+                    Expectation[] expectations = requestResponseLogFilter.getExpectations(httpRequestSerializer.deserialize(request.getBodyAsString()));
+                    writeResponse(ctx, request, HttpResponseStatus.OK, expectationSerializer.serialize(expectations), "application/json");
+                } else {
+                    HttpRequest[] requests = requestLogFilter.retrieve(httpRequestSerializer.deserialize(request.getBodyAsString()));
+                    writeResponse(ctx, request, HttpResponseStatus.OK, httpRequestSerializer.serialize(requests), "application/json");
+                }
 
             } else if (request.matches("PUT", "/verify")) {
 


### PR DESCRIPTION
**Usage**: mockserver:1090/retrieve?type=expectations

This will pull ALL httprequest/httpresponse combinations back for a matching httprequest (or all if httprequest is null).  This is a little different then what dumpToLog was doing, but is going to be used to allow for retrieval of data from a docker container without having to print anything to the logs.

Our use case for this is fairly simple.

As a developer I would like the proxy configured mockserver to provide me every request/response combination I have made to validate an integration test has not changed, thereby allowing me to understand when contracts between services have evolved.

The following is an example of JSON serialized output based upon the unit test
`[
    {
        "httpRequest": {
            "path": "some_path"
        },
        "httpResponse": {
            "statusCode": 200,
            "body": "some_body"
        },
        "times": {
            "remainingTimes": 1,
            "unlimited": false
        },
        "timeToLive": {
            "unlimited": true
        }
    },
    {
        "httpRequest": {
            "path": "some_path"
        },
        "httpResponse": {
            "statusCode": 200,
            "body": "some_body"
        },
        "times": {
            "remainingTimes": 1,
            "unlimited": false
        },
        "timeToLive": {
            "unlimited": true
        }
    },
    {
        "httpRequest": {
            "path": "some_path"
        },
        "httpResponse": {
            "statusCode": 404
        },
        "times": {
            "remainingTimes": 1,
            "unlimited": false
        },
        "timeToLive": {
            "unlimited": true
        }
    },
    {
        "httpRequest": {
            "path": "some_path"
        },
        "httpResponse": {
            "statusCode": 404
        },
        "times": {
            "remainingTimes": 1,
            "unlimited": false
        },
        "timeToLive": {
            "unlimited": true
        }
    },
    {
        "httpRequest": {
            "path": "some_other_path"
        },
        "httpResponse": {
            "statusCode": 200,
            "body": "some_other_body"
        },
        "times": {
            "remainingTimes": 1,
            "unlimited": false
        },
        "timeToLive": {
            "unlimited": true
        }
    }
]`
