### PR TITLE
Convert the request body correctly when it is a String

### DIFF
--- a/mockserver-client-ruby/lib/mockserver/model/request.rb
+++ b/mockserver-client-ruby/lib/mockserver/model/request.rb
@@ -74,6 +74,12 @@ module MockServer::Model
     end
 
     def request_from_json(payload)
+      body = payload['body']
+
+      if body && body.is_a?(String)
+        payload.merge!('body' => { 'type' => :STRING, 'value' => body })
+      end
+
       request = Request.new(symbolize_keys(payload))
       yield request if block_given?
       request

--- a/mockserver-client-ruby/spec/mockserver/model/dsl_spec.rb
+++ b/mockserver-client-ruby/spec/mockserver/model/dsl_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+RSpec.describe 'MockServer::Model::DSL' do
+  let(:header) { MockServer::Model::Header }
+  let(:headers) do
+    [
+      header.new(name: 'User-Agent', values: ['curl/7.22.0 (x86_64-pc-linux-gnu)']),
+      header.new(name: 'Host', values: ['localhost:2000']),
+      header.new(name: 'Accept', values: ['*/*']),
+      header.new(name: 'Content-Length', values: ['26']),
+      header.new(name: 'Content-Type', values: ['application/x-www-form-urlencoded'])
+    ]
+  end
+
+  describe '#request_from_json' do
+    let(:body_content) { 'Hello this is a message' }
+    let(:request_json) do
+      {
+        "method"=>"POST", "path"=>"/message",
+        "headers"=>[{ "name"=>"User-Agent", "values"=>["curl/7.22.0 (x86_64-pc-linux-gnu)"] },
+        {"name"=>"Host", "values"=>["localhost:2000"]}, {"name"=>"Accept", "values"=>["*/*"]},
+        {"name"=>"Content-Length", "values"=>["26"]},
+        {"name"=>"Content-Type", "values"=>["application/x-www-form-urlencoded"]}],
+        "keepAlive"=>true, "secure"=>false
+      }
+    end
+
+    it 'correctly builds the request with no body' do
+      request = request_from_json(request_json)
+
+      expect(request.headers).to eq headers
+      expect(request.body).to eq nil
+    end
+
+    it 'correctly builds the request with a body' do
+      request_with_body = request_json.merge('body' => body_content)
+      request = request_from_json(request_with_body)
+
+      expect(request.headers).to eq headers
+      expect(request.body.type.to_s).to eq 'STRING'
+      expect(request.body.value).to eq body_content
+    end
+  end
+end


### PR DESCRIPTION
so hashie coercion doesnt error when it retrieves and the requests have body content.

As currently if it retrieves a request with body content it errors out with the following;

```
Cannot coerce property :body from String to MockServer::Model::Body: undefined method `each_pair' for "Hello this is a message":String
```

It appears that the mockserver java core doesn't return the type of body and this appears to be implied by this java spec - https://github.com/jamesdbloom/mockserver/blob/master/mockserver-core/src/test/java/org/mockserver/model/HttpRequestTest.java#L96-L114


My gut feeling tells me it ideally should returned from the overridden toString methods in all the classes extending Body like StringBody class below

```
https://github.com/jamesdbloom/mockserver/blob/master/mockserver-core/src/main/java/org/mockserver/model/StringBody.java#L65-L68
```