### PR TITLE
Creating expectations with mock responses and http web hooks

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/client/serialization/java/ExpectationToJavaSerializer.java
+++ b/mockserver-core/src/main/java/org/mockserver/client/serialization/java/ExpectationToJavaSerializer.java
@@ -39,6 +39,11 @@ public class ExpectationToJavaSerializer implements ToJavaSerializer<Expectation
                 output.append(new HttpCallbackToJavaSerializer().serializeAsJava(numberOfSpacesToIndent + 1, expectation.getHttpCallback()));
                 appendNewLineAndIndent(numberOfSpacesToIndent * INDENT_SIZE, output).append(")");
             }
+            if (expectation.getHttpWebHook() != null) {
+                appendNewLineAndIndent(numberOfSpacesToIndent * INDENT_SIZE, output).append(".webHook(");
+                output.append(new HttpWebHookToJavaSerializer().serializeAsJava(numberOfSpacesToIndent + 1, expectation.getHttpWebHook()));
+                appendNewLineAndIndent(numberOfSpacesToIndent * INDENT_SIZE, output).append(")");
+            }
             output.append(";");
         }
         return output.toString();

--- a/mockserver-core/src/main/java/org/mockserver/client/serialization/java/HttpWebHookToJavaSerializer.java
+++ b/mockserver-core/src/main/java/org/mockserver/client/serialization/java/HttpWebHookToJavaSerializer.java
@@ -1,0 +1,33 @@
+package org.mockserver.client.serialization.java;
+
+import static org.mockserver.client.serialization.java.ExpectationToJavaSerializer.INDENT_SIZE;
+
+import org.mockserver.model.HttpWebHook;
+
+import com.google.common.base.Strings;
+
+/**
+ * author Valeriy Mironichev
+ */
+public class HttpWebHookToJavaSerializer implements ToJavaSerializer<HttpWebHook> {
+
+    @Override
+    public String serializeAsJava(int numberOfSpacesToIndent, HttpWebHook httpWebHook) {
+        StringBuffer output = new StringBuffer();
+        if (httpWebHook != null) {
+            appendNewLineAndIndent(numberOfSpacesToIndent * INDENT_SIZE, output).append("callback()");
+            if (httpWebHook.getHttpWebHookConfig() != null) {
+                appendNewLineAndIndent((numberOfSpacesToIndent + 1) * INDENT_SIZE, output)
+                        .append(".withHttpWebHookConfig(\"").append(httpWebHook.getHttpWebHookConfig()).append("\")");
+            }
+        }
+
+        return output.toString();
+    }
+
+    private StringBuffer appendNewLineAndIndent(int numberOfSpacesToIndent, StringBuffer output) {
+        return output.append(System.getProperty("line.separator"))
+                .append(Strings.padStart("", numberOfSpacesToIndent, ' '));
+    }
+
+}

--- a/mockserver-core/src/main/java/org/mockserver/client/serialization/model/ExpectationDTO.java
+++ b/mockserver-core/src/main/java/org/mockserver/client/serialization/model/ExpectationDTO.java
@@ -15,6 +15,7 @@ public class ExpectationDTO extends ObjectWithJsonToString {
     private HttpForwardDTO httpForward;
     private HttpErrorDTO httpError;
     private HttpCallbackDTO httpCallback;
+    private HttpWebHookDTO httpWebHook;
     private TimesDTO times;
     private TimeToLiveDTO timeToLive;
 
@@ -40,6 +41,10 @@ public class ExpectationDTO extends ObjectWithJsonToString {
             if (httpCallback != null) {
                 this.httpCallback = new HttpCallbackDTO(httpCallback);
             }
+            HttpWebHook httpWebHook = expectation.getHttpWebHook();
+            if (httpWebHook != null) {
+                this.httpWebHook = new HttpWebHookDTO(httpWebHook);
+            }
             Times times = expectation.getTimes();
             if (times != null) {
                 this.times = new TimesDTO(times);
@@ -60,6 +65,7 @@ public class ExpectationDTO extends ObjectWithJsonToString {
         HttpForward httpForward = null;
         HttpError httpError = null;
         HttpCallback httpCallback = null;
+        HttpWebHook httpWebHook = null;
         Times times;
         TimeToLive timeToLive;
         if (this.httpRequest != null) {
@@ -77,6 +83,9 @@ public class ExpectationDTO extends ObjectWithJsonToString {
         if (this.httpCallback != null) {
             httpCallback = this.httpCallback.buildObject();
         }
+        if (this.httpWebHook != null) {
+            httpWebHook = this.httpWebHook.buildObject(httpResponse);
+        }
         if (this.times != null) {
             times = this.times.buildObject();
         } else {
@@ -87,7 +96,8 @@ public class ExpectationDTO extends ObjectWithJsonToString {
         } else {
             timeToLive = TimeToLive.unlimited();
         }
-        return new Expectation(httpRequest, times, timeToLive).thenRespond(httpResponse).thenForward(httpForward).thenError(httpError).thenCallback(httpCallback);
+        return new Expectation(httpRequest, times, timeToLive).thenRespond(httpResponse).thenForward(httpForward)
+                .thenError(httpError).thenCallback(httpCallback).thenHttpWebHook(httpWebHook);
     }
 
     public HttpRequestDTO getHttpRequest() {
@@ -133,6 +143,15 @@ public class ExpectationDTO extends ObjectWithJsonToString {
     public ExpectationDTO setHttpCallback(HttpCallbackDTO httpCallback) {
         this.httpCallback = httpCallback;
         return this;
+    }
+
+    public ExpectationDTO setHttpWebHook(HttpWebHookDTO httpWebHook) {
+        this.httpWebHook = httpWebHook;
+        return this;
+    }
+
+    public HttpWebHookDTO getHttpWebHook() {
+        return httpWebHook;
     }
 
     public TimesDTO getTimes() {

--- a/mockserver-core/src/main/java/org/mockserver/client/serialization/model/HttpWebHookDTO.java
+++ b/mockserver-core/src/main/java/org/mockserver/client/serialization/model/HttpWebHookDTO.java
@@ -1,0 +1,36 @@
+package org.mockserver.client.serialization.model;
+
+import org.mockserver.model.HttpWebHookConfig;
+import org.mockserver.model.ObjectWithReflectiveEqualsHashCodeToString;
+import org.mockserver.model.HttpResponse;
+import org.mockserver.model.HttpWebHook;
+
+/**
+ * author Valeriy Mironichev
+ */
+public class HttpWebHookDTO extends ObjectWithReflectiveEqualsHashCodeToString {
+
+    private HttpWebHookConfig httpWebHookConfig;
+
+    public HttpWebHookDTO(HttpWebHook httpWebHook) {
+        if (httpWebHook != null) {
+            httpWebHookConfig = httpWebHook.getHttpWebHookConfig();
+        }
+    }
+
+    public HttpWebHookDTO() {
+    }
+
+    public HttpWebHook buildObject(HttpResponse httpResponse) {
+        return new HttpWebHook().withHttpWebHookConfig(httpWebHookConfig).withHttpResponse(httpResponse);
+    }
+
+    public HttpWebHookConfig getHttpWebHookConfig() {
+        return httpWebHookConfig;
+    }
+
+    public void setHttpWebHookConfig(HttpWebHookConfig httpWebHookConfig) {
+        this.httpWebHookConfig = httpWebHookConfig;
+    }
+
+}

--- a/mockserver-core/src/main/java/org/mockserver/mock/action/ActionHandler.java
+++ b/mockserver-core/src/main/java/org/mockserver/mock/action/ActionHandler.java
@@ -15,6 +15,7 @@ public class ActionHandler {
     private HttpForwardActionHandler httpForwardActionHandler = new HttpForwardActionHandler();
     private HttpCallbackActionHandler httpCallbackActionHandler = new HttpCallbackActionHandler();
     private HttpResponseActionHandler httpResponseActionHandler = new HttpResponseActionHandler();
+    private HttpWebHookActionHandler httpWebHookActionHandler = new HttpWebHookActionHandler();
     private Filters filters = new Filters();
 
     public ActionHandler(RequestLogFilter requestLogFilter) {
@@ -35,6 +36,9 @@ public class ActionHandler {
                     break;
                 case RESPONSE:
                     httpResponse = httpResponseActionHandler.handle((HttpResponse) action);
+                    break;
+                case RESPONSE_AND_WEBHOOKS:
+                    httpResponse = httpWebHookActionHandler.handle((HttpWebHook) action, httpRequest);
                     break;
             }
         }

--- a/mockserver-core/src/main/java/org/mockserver/mock/action/HttpCallbackActionHandler.java
+++ b/mockserver-core/src/main/java/org/mockserver/mock/action/HttpCallbackActionHandler.java
@@ -18,7 +18,7 @@ import static org.mockserver.model.HttpResponse.notFoundResponse;
  */
 public class HttpCallbackActionHandler {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
-    private final Map<String, ExpectationCallback> httpCallBackRegistry = new ConcurrentHashMap<String, ExpectationCallback>();
+    private final ConcurrentHashMap<String, ExpectationCallback> httpCallBackRegistry = new ConcurrentHashMap<String, ExpectationCallback>();
 
     public HttpResponse handle(HttpCallback httpCallback, HttpRequest httpRequest) {
         return sendRequest(httpCallback, httpRequest);

--- a/mockserver-core/src/main/java/org/mockserver/mock/action/HttpWebHookActionHandler.java
+++ b/mockserver-core/src/main/java/org/mockserver/mock/action/HttpWebHookActionHandler.java
@@ -1,0 +1,27 @@
+package org.mockserver.mock.action;
+
+import java.util.List;
+
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.mockserver.model.HttpWebHook;
+import org.mockserver.model.HttpWebHookConfig;
+import org.mockserver.model.HttpWebHookRequest;
+
+/**
+ * author Valeriy Mironichev
+ */
+public class HttpWebHookActionHandler extends HttpResponseActionHandler {
+
+    public HttpResponse handle(HttpWebHook httpWebHook, HttpRequest httpRequest) {
+
+        HttpWebHookConfig callbackConfig = httpWebHook.getHttpWebHookConfig();
+        if (callbackConfig != null) {
+            List<HttpWebHookRequest> requests = callbackConfig.getEndpoints();
+            for (HttpWebHookRequest request : requests) {
+                request.submit();
+            }
+        }
+        return httpWebHook.getHttpResponse();
+    }
+}

--- a/mockserver-core/src/main/java/org/mockserver/model/Action.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/Action.java
@@ -14,6 +14,7 @@ public abstract class Action extends ObjectWithJsonToString {
         FORWARD,
         RESPONSE,
         CALLBACK,
+        RESPONSE_AND_WEBHOOKS,
         ERROR
     }
 }

--- a/mockserver-core/src/main/java/org/mockserver/model/HttpWebHook.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/HttpWebHook.java
@@ -1,0 +1,49 @@
+package org.mockserver.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * author Valeriy Mironichev
+ */
+public class HttpWebHook extends Action {
+    private HttpWebHookConfig httpWebHookConfig;
+    @JsonIgnore
+    private HttpResponse httpResponse;
+
+    @Override
+    @JsonIgnore
+    public Type getType() {
+        return Type.RESPONSE_AND_WEBHOOKS;
+    }
+
+    public HttpWebHookConfig getHttpWebHookConfig() {
+        return httpWebHookConfig;
+    }
+
+    public void setHttpWebHookConfig(HttpWebHookConfig httpWebHookConfig) {
+        this.httpWebHookConfig = httpWebHookConfig;
+    }
+
+    public HttpWebHook withHttpWebHookConfig(HttpWebHookConfig callbackConfig) {
+        this.httpWebHookConfig = callbackConfig;
+        return this;
+    }
+
+    public HttpResponse getHttpResponse() {
+        return httpResponse;
+    }
+
+    public void setHttpResponse(HttpResponse httpResponse) {
+        this.httpResponse = httpResponse;
+    }
+
+    public HttpWebHook withHttpResponse(HttpResponse httpResponse) {
+        this.httpResponse = httpResponse;
+        return this;
+    }
+
+    public HttpWebHook applyHttpResponseDelay() {
+        httpResponse.applyDelay();
+        return this;
+    }
+}

--- a/mockserver-core/src/main/java/org/mockserver/model/HttpWebHookConfig.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/HttpWebHookConfig.java
@@ -1,0 +1,22 @@
+package org.mockserver.model;
+
+import java.util.List;
+
+/**
+ * author Valeriy Mironichev
+ */
+public class HttpWebHookConfig {
+    private List<HttpWebHookRequest> endpoints;
+
+    public HttpWebHookConfig() {
+    }
+
+    public List<HttpWebHookRequest> getEndpoints() {
+        return endpoints;
+    }
+
+    public void setEndpoints(List<HttpWebHookRequest> endpoints) {
+        this.endpoints = endpoints;
+    }
+
+}

--- a/mockserver-core/src/main/java/org/mockserver/model/HttpWebHookRequest.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/HttpWebHookRequest.java
@@ -1,0 +1,97 @@
+package org.mockserver.model;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.mockserver.client.netty.NettyHttpClient;
+import org.mockserver.logging.LogFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * author Valeriy Mironichev
+ */
+public class HttpWebHookRequest extends ObjectWithReflectiveEqualsHashCodeToString {
+    
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private LogFormatter logFormatter = new LogFormatter(logger);
+
+    private static NettyHttpClient httpClient = new NettyHttpClient();
+    private static ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+    private String host;
+    private int port;
+    private String path;
+    private String payload;
+    private long executionDelay;
+    private TimeUnit executionDelayTimeUnit;
+
+    public HttpWebHookRequest() {
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public void setPayload(String payload) {
+        this.payload = payload;
+    }
+
+    public long getExecutionDelay() {
+        return executionDelay;
+    }
+
+    public void setExecutionDelay(long executionDelay) {
+        this.executionDelay = executionDelay;
+    }
+
+    public TimeUnit getExecutionDelayTimeUnit() {
+        return executionDelayTimeUnit;
+    }
+
+    public void setExecutionDelayTimeUnit(TimeUnit executionDelayTimeUnit) {
+        this.executionDelayTimeUnit = executionDelayTimeUnit;
+    }
+
+    public void submit() {
+        logFormatter.infoLog("Scheduling web hook for execution {}", this);
+        executorService.schedule(new Runnable() {
+            @Override
+            public void run() {
+                HttpRequest httpRequest = new HttpRequest()
+                        .withBody(payload)
+                        .withHeader("Content-type", "application/json")
+                        .withMethod("POST")
+                        .withPath(path == null ? "/" : path);
+                OutboundHttpRequest outbondHttpRequest = new OutboundHttpRequest(host, port, null, httpRequest);
+                HttpResponse response = httpClient.sendRequest(outbondHttpRequest);
+                logFormatter.infoLog("Web hook executed, response recevied: {}" + System.getProperty("line.separator") + " for request:{}", response, httpRequest);
+                System.out.println("received response: " + response.getBodyAsString());
+            }
+        }, executionDelay, executionDelayTimeUnit);
+    }
+}

--- a/mockserver-core/src/main/java/org/mockserver/model/HttpWebHookRequest.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/HttpWebHookRequest.java
@@ -13,10 +13,9 @@ import org.slf4j.LoggerFactory;
  * author Valeriy Mironichev
  */
 public class HttpWebHookRequest extends ObjectWithReflectiveEqualsHashCodeToString {
-    
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
-    private LogFormatter logFormatter = new LogFormatter(logger);
 
+    private final Logger logger = LoggerFactory.getLogger(HttpWebHookRequest.class);
+    private LogFormatter logFormatter = new LogFormatter(logger);
     private static NettyHttpClient httpClient = new NettyHttpClient();
     private static ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
     private String host;
@@ -33,53 +32,63 @@ public class HttpWebHookRequest extends ObjectWithReflectiveEqualsHashCodeToStri
         return host;
     }
 
-    public void setHost(String host) {
+    public HttpWebHookRequest setHost(String host) {
         this.host = host;
+        return this;
     }
 
     public int getPort() {
         return port;
     }
 
-    public void setPort(int port) {
+    public HttpWebHookRequest setPort(int port) {
         this.port = port;
+        return this;
     }
 
     public String getPath() {
         return path;
     }
 
-    public void setPath(String path) {
+    public HttpWebHookRequest setPath(String path) {
         this.path = path;
+        return this;
     }
 
     public String getPayload() {
         return payload;
     }
 
-    public void setPayload(String payload) {
+    public HttpWebHookRequest setPayload(String payload) {
         this.payload = payload;
+        return this;
     }
 
     public long getExecutionDelay() {
         return executionDelay;
     }
 
-    public void setExecutionDelay(long executionDelay) {
+    public HttpWebHookRequest setExecutionDelay(long executionDelay) {
         this.executionDelay = executionDelay;
+        return this;
     }
 
     public TimeUnit getExecutionDelayTimeUnit() {
-        return executionDelayTimeUnit;
+        return executionDelayTimeUnit == null ? TimeUnit.MILLISECONDS : executionDelayTimeUnit;
     }
 
-    public void setExecutionDelayTimeUnit(TimeUnit executionDelayTimeUnit) {
+    public HttpWebHookRequest setExecutionDelayTimeUnit(TimeUnit executionDelayTimeUnit) {
         this.executionDelayTimeUnit = executionDelayTimeUnit;
+        return this;
     }
 
     public void submit() {
         logFormatter.infoLog("Scheduling web hook for execution {}", this);
-        executorService.schedule(new Runnable() {
+        executorService.schedule(webHookRequest(), getExecutionDelay(), getExecutionDelayTimeUnit());
+    }
+
+    private Runnable webHookRequest() {
+        return new Runnable() {
             @Override
             public void run() {
                 HttpRequest httpRequest = new HttpRequest()
@@ -92,6 +101,6 @@ public class HttpWebHookRequest extends ObjectWithReflectiveEqualsHashCodeToStri
                 logFormatter.infoLog("Web hook executed, response recevied: {}" + System.getProperty("line.separator") + " for request:{}", response, httpRequest);
                 System.out.println("received response: " + response.getBodyAsString());
             }
-        }, executionDelay, executionDelayTimeUnit);
+        };
     }
 }

--- a/mockserver-netty/src/main/java/org/mockserver/mockserver/MockServerHandler.java
+++ b/mockserver-netty/src/main/java/org/mockserver/mockserver/MockServerHandler.java
@@ -93,7 +93,7 @@ public class MockServerHandler extends SimpleChannelInboundHandler<HttpRequest> 
                 List<String> validationErrors = expectationValidator.isValid(expectation);
                 if (validationErrors.isEmpty()) {
                     SSLFactory.addSubjectAlternativeName(expectation.getHttpRequest().getFirstHeader(HttpHeaders.Names.HOST));
-                    mockServerMatcher.when(expectation.getHttpRequest(), expectation.getTimes(), expectation.getTimeToLive()).thenRespond(expectation.getHttpResponse(false)).thenForward(expectation.getHttpForward()).thenError(expectation.getHttpError()).thenCallback(expectation.getHttpCallback());
+                    mockServerMatcher.when(expectation.getHttpRequest(), expectation.getTimes(), expectation.getTimeToLive()).thenRespond(expectation.getHttpResponse(false)).thenForward(expectation.getHttpForward()).thenError(expectation.getHttpError()).thenCallback(expectation.getHttpCallback()).thenHttpWebHook(expectation.getHttpWebHook());
                     logFormatter.infoLog("creating expectation:{}", expectation);
                     writeResponse(ctx, request, HttpResponseStatus.CREATED);
                 } else {


### PR DESCRIPTION
This feature gives possibility to create optionally one or more web hooks for specific expectation along with prepared http response, nodejs expectation configuration example:

``` javascript
var httpMockResponse = {
    'httpRequest': httpRequestExpectation,
    'httpResponse': {
        'statusCode': requestConfig.http_response_code,
        'body': JSON.stringify(responseBody),
    },
    'httpWebHook': {
       'httpWebHookConfig': 'endpoints': [
           {
                'host': 'localhost',
                'port': '4567',
                'path': '/',
                'payload': JSON.stringify('{"name":"test_value"}'),
                'executionDelay': 5000,
                'executionDelayTimeUnit': 'MILLISECONDS'
           }
        ]
    }
}

mockServerClient("localhost", SERVER_PORT).mockAnyResponse(httpMockResponse);
```
