### PR TITLE
[WIP] Allow explicitly specifying protocol and/or base path

### DIFF
--- a/mockserver-client-java/src/main/java/org/mockserver/client/AbstractClient.java
+++ b/mockserver-client-java/src/main/java/org/mockserver/client/AbstractClient.java
@@ -21,8 +21,10 @@ public abstract class AbstractClient {
 
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
+    protected final HttpRequest.Protocol protocol;
     protected final String host;
     protected final int port;
+    protected final String basePath;
     protected final String contextPath;
     protected NettyHttpClient nettyHttpClient = new NettyHttpClient();
     protected HttpRequestSerializer httpRequestSerializer = new HttpRequestSerializer();
@@ -47,8 +49,24 @@ public abstract class AbstractClient {
         if (contextPath == null) {
             throw new IllegalArgumentException("ContextPath can not be null");
         }
+        this.protocol = HttpRequest.Protocol.any;
         this.host = host;
         this.port = port;
+        this.basePath = "";
+        this.contextPath = cleanContextPath(contextPath);
+    }
+
+    public AbstractClient(HttpRequest.Protocol protocol, String host, int port, String basePath, String contextPath) {
+        if (StringUtils.isEmpty(host)) {
+            throw new IllegalArgumentException("Host can not be null or empty");
+        }
+        if (contextPath == null) {
+            throw new IllegalArgumentException("ContextPath can not be null");
+        }
+        this.protocol = protocol;
+        this.host = host;
+        this.port = port;
+        this.basePath = cleanContextPath(basePath);
         this.contextPath = cleanContextPath(contextPath);
     }
 
@@ -69,7 +87,7 @@ public abstract class AbstractClient {
     }
 
     protected HttpResponse sendRequest(HttpRequest httpRequest) {
-        return nettyHttpClient.sendRequest(outboundRequest(host, port, contextPath, httpRequest));
+        return nettyHttpClient.sendRequest(outboundRequest(protocol, host, port, StringUtils.isEmpty(basePath) ? contextPath : basePath + "/" + contextPath, httpRequest));
     }
 
     protected String formatErrorMessage(String message, Object... objects) {

--- a/mockserver-client-java/src/main/java/org/mockserver/client/server/MockServerClient.java
+++ b/mockserver-client-java/src/main/java/org/mockserver/client/server/MockServerClient.java
@@ -31,7 +31,7 @@ public class MockServerClient extends AbstractClient {
      * @param port the port for the MockServer to communicate with
      */
     public MockServerClient(String host, int port) {
-        this(host, port, "");
+        this(HttpRequest.Protocol.any, host, port, "", "");
     }
 
     /**
@@ -45,7 +45,21 @@ public class MockServerClient extends AbstractClient {
      * @param contextPath the context path that the MockServer war is deployed to
      */
     public MockServerClient(String host, int port, String contextPath) {
-        super(host, port, contextPath);
+        this(HttpRequest.Protocol.any, host, port, "", contextPath);
+    }
+
+    /**
+     * Start the client communicating to a MockServer at the specified host, port, base path
+     * and contextPath, and the specified protocol for example:
+     *
+     *   MockServerClient mockServerClient = new MockServerClient("localhost", 1080, "/mockserver");
+     *
+     * @param host the host for the MockServer to communicate with
+     * @param port the port for the MockServer to communicate with
+     * @param contextPath the context path that the MockServer war is deployed to
+     */
+    public MockServerClient(HttpRequest.Protocol protocol, String host, int port, String basePath, String contextPath) {
+        super(protocol, host, port, basePath, contextPath);
     }
 
     /**

--- a/mockserver-core/src/main/java/org/mockserver/client/netty/NettyHttpClient.java
+++ b/mockserver-core/src/main/java/org/mockserver/client/netty/NettyHttpClient.java
@@ -1,3 +1,4 @@
+
 package org.mockserver.client.netty;
 
 import io.netty.bootstrap.Bootstrap;
@@ -36,7 +37,16 @@ public class NettyHttpClient {
         // configure the client
         EventLoopGroup group = new NioEventLoopGroup();
 
-        boolean isSsl = httpRequest.isSecure() != null && httpRequest.isSecure();
+        boolean isSsl;
+        switch (httpRequest.getProtocol()) {
+            case HTTPS:
+                isSsl = true;
+                break;
+            default:
+                isSsl = false;
+                break;
+        }
+        isSsl = isSsl || httpRequest.isSecure() != null && httpRequest.isSecure();
         try {
             final HttpClientInitializer channelInitializer = new HttpClientInitializer(isSsl);
 

--- a/mockserver-core/src/main/java/org/mockserver/model/HttpRequest.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/HttpRequest.java
@@ -24,6 +24,13 @@ public class HttpRequest extends Not {
     Boolean keepAlive = null;
     Boolean secure = null;
 
+    public enum Protocol {
+        HTTP,
+        HTTPS,
+        SOCKS,
+        any
+    }
+
     public static HttpRequest request() {
         return new HttpRequest();
     }

--- a/mockserver-core/src/main/java/org/mockserver/model/OutboundHttpRequest.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/OutboundHttpRequest.java
@@ -10,11 +10,13 @@ import java.net.InetSocketAddress;
  */
 public class OutboundHttpRequest extends HttpRequest {
 
+    private Protocol protocol;
     private String hostname;
     private int port;
     private String contextPath;
 
     public OutboundHttpRequest(String hostname, int port, String contextPath, HttpRequest httpRequest) {
+        this.protocol = Protocol.any;
         this.hostname = hostname;
         this.port = port;
         this.contextPath = Strings.nullToEmpty(contextPath);
@@ -26,6 +28,11 @@ public class OutboundHttpRequest extends HttpRequest {
         this.headers = httpRequest.headers;
         this.cookies = httpRequest.cookies;
         this.keepAlive = httpRequest.keepAlive;
+    }
+
+    public OutboundHttpRequest(Protocol protocol, String hostname, int port, String contextPath, HttpRequest httpRequest) {
+        this(hostname, port, contextPath, httpRequest);
+        this.protocol = protocol;
     }
 
     public static OutboundHttpRequest outboundRequest(InetSocketAddress inetSocketAddress, String contextPath, HttpRequest httpRequest) {
@@ -56,7 +63,11 @@ public class OutboundHttpRequest extends HttpRequest {
     }
 
     public static OutboundHttpRequest outboundRequest(String hostname, int port, String contextPath, HttpRequest httpRequest) {
-        return new OutboundHttpRequest(hostname, port, contextPath, httpRequest);
+        return outboundRequest(Protocol.any, hostname, port, contextPath, httpRequest);
+    }
+
+    public static OutboundHttpRequest outboundRequest(Protocol protocol, String hostname, int port, String contextPath, HttpRequest httpRequest) {
+        return new OutboundHttpRequest(protocol, hostname, port, contextPath, httpRequest);
     }
 
     public InetSocketAddress getDestination() {
@@ -75,5 +86,9 @@ public class OutboundHttpRequest extends HttpRequest {
         }
         super.withSecure(isSsl);
         return this;
+    }
+
+    public Protocol getProtocol() {
+        return protocol;
     }
 }


### PR DESCRIPTION
We have a setup necessitating two additional configuration options:
1. Being able to force HTTPS
2. Specifiying a base path independent from an app context

Consider this a basis for discussion - I may split this up into two distinct requests if required and will squash/rebase as necessary .

I tried keeping it as general as possible, as well as not messing with existing code paths.
