### PR TITLE
remove outdated Xerces dependency and fix XML pretty print issue

### DIFF
--- a/mockserver-core/pom.xml
+++ b/mockserver-core/pom.xml
@@ -95,12 +95,6 @@
             <artifactId>json-schema-validator</artifactId>
         </dependency>
 
-        <!-- xml -->
-        <dependency>
-            <groupId>xerces</groupId>
-            <artifactId>xerces</artifactId>
-        </dependency>
-
         <!-- commons & guava -->
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/mockserver-core/src/main/java/org/mockserver/matchers/StringToXmlDocumentParser.java
+++ b/mockserver-core/src/main/java/org/mockserver/matchers/StringToXmlDocumentParser.java
@@ -1,9 +1,5 @@
 package org.mockserver.matchers;
 
-import com.google.common.base.Charsets;
-import org.apache.xml.serialize.Method;
-import org.apache.xml.serialize.OutputFormat;
-import org.apache.xml.serialize.XMLSerializer;
 import org.mockserver.model.ObjectWithReflectiveEqualsHashCodeToString;
 import org.w3c.dom.Document;
 import org.xml.sax.ErrorHandler;
@@ -14,9 +10,12 @@ import org.xml.sax.SAXParseException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import java.io.ByteArrayOutputStream;
+import javax.xml.transform.*;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 import java.io.IOException;
 import java.io.StringReader;
+import java.io.StringWriter;
 
 /**
  * @author jamesdbloom
@@ -28,9 +27,19 @@ public class StringToXmlDocumentParser extends ObjectWithReflectiveEqualsHashCod
     }
 
     private String prettyPrintXmlDocument(Document doc) throws IOException {
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        new XMLSerializer(byteArrayOutputStream, new OutputFormat(Method.XML, Charsets.UTF_8.name(), true)).serialize(doc);
-        return byteArrayOutputStream.toString(Charsets.UTF_8.name());
+        try {
+            Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "3");
+            StreamResult result = new StreamResult(new StringWriter());
+            DOMSource source = new DOMSource(doc);
+            transformer.transform(source, result);
+            return result.getWriter().toString();
+        } catch (TransformerConfigurationException e) {
+            throw new IOException(e);
+        } catch (TransformerException e) {
+            throw new IOException(e);
+        }
     }
 
     public Document buildDocument(final String matched, final ErrorLogger errorLogger) throws ParserConfigurationException, IOException, SAXException {

--- a/mockserver-core/src/test/java/org/mockserver/matchers/XmlStringMatcherTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/matchers/XmlStringMatcherTest.java
@@ -11,49 +11,49 @@ import static org.mockserver.model.NottableString.string;
  */
 public class XmlStringMatcherTest {
 
-    private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+    private static final String NL = System.getProperty("line.separator");
 
     @Test
     public void shouldMatchMatchingXML() {
         String matched = "" +
-                "<element>" + LINE_SEPARATOR +
-                "   <key>some_key</key>" + LINE_SEPARATOR +
-                "   <value>some_value</value>" + LINE_SEPARATOR +
+                "<element>" + NL +
+                "   <key>some_key</key>" + NL +
+                "   <value>some_value</value>" + NL +
                 "</element>";
         assertTrue(new XmlStringMatcher("<element><key>some_key</key><value>some_value</value></element>").matches(matched));
         assertTrue(new XmlStringMatcher("" +
-                "<element>" + LINE_SEPARATOR +
-                "   <key>some_key</key>" + LINE_SEPARATOR +
-                "   <value>some_value</value>" + LINE_SEPARATOR +
+                "<element>" + NL +
+                "   <key>some_key</key>" + NL +
+                "   <value>some_value</value>" + NL +
                 "</element>").matches(matched));
     }
 
     @Test
     public void shouldNotMatchMatchingXMLWithNot() {
         String matched = "" +
-                "<element>" + LINE_SEPARATOR +
-                "   <key>some_key</key>" + LINE_SEPARATOR +
-                "   <value>some_value</value>" + LINE_SEPARATOR +
+                "<element>" + NL +
+                "   <key>some_key</key>" + NL +
+                "   <value>some_value</value>" + NL +
                 "</element>";
         assertFalse(not(new XmlStringMatcher("<element><key>some_key</key><value>some_value</value></element>")).matches(matched));
         assertFalse(not(new XmlStringMatcher("" +
-                "<element>" + LINE_SEPARATOR +
-                "   <key>some_key</key>" + LINE_SEPARATOR +
-                "   <value>some_value</value>" + LINE_SEPARATOR +
+                "<element>" + NL +
+                "   <key>some_key</key>" + NL +
+                "   <value>some_value</value>" + NL +
                 "</element>")).matches(matched));
     }
 
     @Test
     public void shouldMatchMatchingXMLWithDifferentAttributeOrder() {
         String matched = "" +
-                "<element attributeOne=\"one\" attributeTwo=\"two\">" + LINE_SEPARATOR +
-                "   <key attributeOne=\"one\" attributeTwo=\"two\">some_key</key>" + LINE_SEPARATOR +
-                "   <value>some_value</value>" + LINE_SEPARATOR +
+                "<element attributeOne=\"one\" attributeTwo=\"two\">" + NL +
+                "   <key attributeOne=\"one\" attributeTwo=\"two\">some_key</key>" + NL +
+                "   <value>some_value</value>" + NL +
                 "</element>";
         assertTrue(new XmlStringMatcher("<element attributeTwo=\"two\" attributeOne=\"one\"><key attributeTwo=\"two\" attributeOne=\"one\">some_key</key><value>some_value</value></element>").matches(matched));
-        assertTrue(new XmlStringMatcher("<element attributeTwo=\"two\" attributeOne=\"one\">" + LINE_SEPARATOR +
-                "   <key attributeTwo=\"two\" attributeOne=\"one\">some_key</key>" + LINE_SEPARATOR +
-                "   <value>some_value</value>" + LINE_SEPARATOR +
+        assertTrue(new XmlStringMatcher("<element attributeTwo=\"two\" attributeOne=\"one\">" + NL +
+                "   <key attributeTwo=\"two\" attributeOne=\"one\">some_key</key>" + NL +
+                "   <value>some_value</value>" + NL +
                 "</element>").matches(matched));
     }
 

--- a/mockserver-core/src/test/java/org/mockserver/matchers/XmlStringMatcherTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/matchers/XmlStringMatcherTest.java
@@ -11,47 +11,49 @@ import static org.mockserver.model.NottableString.string;
  */
 public class XmlStringMatcherTest {
 
+    private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+
     @Test
     public void shouldMatchMatchingXML() {
         String matched = "" +
-                "<element>" +
-                "   <key>some_key</key>" +
-                "   <value>some_value</value>" +
+                "<element>" + LINE_SEPARATOR +
+                "   <key>some_key</key>" + LINE_SEPARATOR +
+                "   <value>some_value</value>" + LINE_SEPARATOR +
                 "</element>";
         assertTrue(new XmlStringMatcher("<element><key>some_key</key><value>some_value</value></element>").matches(matched));
         assertTrue(new XmlStringMatcher("" +
-                "<element>" +
-                "   <key>some_key</key>" +
-                "   <value>some_value</value>" +
+                "<element>" + LINE_SEPARATOR +
+                "   <key>some_key</key>" + LINE_SEPARATOR +
+                "   <value>some_value</value>" + LINE_SEPARATOR +
                 "</element>").matches(matched));
     }
 
     @Test
     public void shouldNotMatchMatchingXMLWithNot() {
         String matched = "" +
-                "<element>" +
-                "   <key>some_key</key>" +
-                "   <value>some_value</value>" +
+                "<element>" + LINE_SEPARATOR +
+                "   <key>some_key</key>" + LINE_SEPARATOR +
+                "   <value>some_value</value>" + LINE_SEPARATOR +
                 "</element>";
         assertFalse(not(new XmlStringMatcher("<element><key>some_key</key><value>some_value</value></element>")).matches(matched));
         assertFalse(not(new XmlStringMatcher("" +
-                "<element>" +
-                "   <key>some_key</key>" +
-                "   <value>some_value</value>" +
+                "<element>" + LINE_SEPARATOR +
+                "   <key>some_key</key>" + LINE_SEPARATOR +
+                "   <value>some_value</value>" + LINE_SEPARATOR +
                 "</element>")).matches(matched));
     }
 
     @Test
     public void shouldMatchMatchingXMLWithDifferentAttributeOrder() {
         String matched = "" +
-                "<element attributeOne=\"one\" attributeTwo=\"two\">" +
-                "   <key attributeOne=\"one\" attributeTwo=\"two\">some_key</key>" +
-                "   <value>some_value</value>" +
+                "<element attributeOne=\"one\" attributeTwo=\"two\">" + LINE_SEPARATOR +
+                "   <key attributeOne=\"one\" attributeTwo=\"two\">some_key</key>" + LINE_SEPARATOR +
+                "   <value>some_value</value>" + LINE_SEPARATOR +
                 "</element>";
         assertTrue(new XmlStringMatcher("<element attributeTwo=\"two\" attributeOne=\"one\"><key attributeTwo=\"two\" attributeOne=\"one\">some_key</key><value>some_value</value></element>").matches(matched));
-        assertTrue(new XmlStringMatcher("<element attributeTwo=\"two\" attributeOne=\"one\">" +
-                "   <key attributeTwo=\"two\" attributeOne=\"one\">some_key</key>" +
-                "   <value>some_value</value>" +
+        assertTrue(new XmlStringMatcher("<element attributeTwo=\"two\" attributeOne=\"one\">" + LINE_SEPARATOR +
+                "   <key attributeTwo=\"two\" attributeOne=\"one\">some_key</key>" + LINE_SEPARATOR +
+                "   <value>some_value</value>" + LINE_SEPARATOR +
                 "</element>").matches(matched));
     }
 

--- a/mockserver-integration-testing/src/main/java/org/mockserver/integration/server/AbstractClientServerIntegrationTest.java
+++ b/mockserver-integration-testing/src/main/java/org/mockserver/integration/server/AbstractClientServerIntegrationTest.java
@@ -58,6 +58,8 @@ import static org.mockserver.model.XmlBody.xml;
 public abstract class AbstractClientServerIntegrationTest {
 
     public static final String TEXT_PLAIN = MediaType.create("text", "plain").toString();
+    protected static final String NL = System.getProperty("line.separator");
+
     protected static MockServerClient mockServerClient;
     protected static String servletContext = "";
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
@@ -817,26 +819,26 @@ public abstract class AbstractClientServerIntegrationTest {
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
                                 .withBody(new StringBody("" +
-                                        "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + System.getProperty("line.separator") +
-                                        "<bookstore>" + System.getProperty("line.separator") +
-                                        "  <book category=\"COOKING\">" + System.getProperty("line.separator") +
-                                        "    <title lang=\"en\">Everyday Italian</title>" + System.getProperty("line.separator") +
-                                        "    <author>Giada De Laurentiis</author>" + System.getProperty("line.separator") +
-                                        "    <year>2005</year>" + System.getProperty("line.separator") +
-                                        "    <price>30.00</price>" + System.getProperty("line.separator") +
-                                        "  </book>" + System.getProperty("line.separator") +
-                                        "  <book category=\"CHILDREN\">" + System.getProperty("line.separator") +
-                                        "    <title lang=\"en\">Harry Potter</title>" + System.getProperty("line.separator") +
-                                        "    <author>J K. Rowling</author>" + System.getProperty("line.separator") +
-                                        "    <year>2005</year>" + System.getProperty("line.separator") +
-                                        "    <price>29.99</price>" + System.getProperty("line.separator") +
-                                        "  </book>" + System.getProperty("line.separator") +
-                                        "  <book category=\"WEB\">" + System.getProperty("line.separator") +
-                                        "    <title lang=\"en\">Learning XML</title>" + System.getProperty("line.separator") +
-                                        "    <author>Erik T. Ray</author>" + System.getProperty("line.separator") +
-                                        "    <year>2003</year>" + System.getProperty("line.separator") +
-                                        "    <price>31.95</price>" + System.getProperty("line.separator") +
-                                        "  </book>" + System.getProperty("line.separator") +
+                                        "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + NL +
+                                        "<bookstore>" + NL +
+                                        "  <book category=\"COOKING\">" + NL +
+                                        "    <title lang=\"en\">Everyday Italian</title>" + NL +
+                                        "    <author>Giada De Laurentiis</author>" + NL +
+                                        "    <year>2005</year>" + NL +
+                                        "    <price>30.00</price>" + NL +
+                                        "  </book>" + NL +
+                                        "  <book category=\"CHILDREN\">" + NL +
+                                        "    <title lang=\"en\">Harry Potter</title>" + NL +
+                                        "    <author>J K. Rowling</author>" + NL +
+                                        "    <year>2005</year>" + NL +
+                                        "    <price>29.99</price>" + NL +
+                                        "  </book>" + NL +
+                                        "  <book category=\"WEB\">" + NL +
+                                        "    <title lang=\"en\">Learning XML</title>" + NL +
+                                        "    <author>Erik T. Ray</author>" + NL +
+                                        "    <year>2003</year>" + NL +
+                                        "    <price>31.95</price>" + NL +
+                                        "  </book>" + NL +
                                         "</bookstore>")),
                         headersToIgnore)
         );
@@ -852,26 +854,26 @@ public abstract class AbstractClientServerIntegrationTest {
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
                                 .withBody(new StringBody("" +
-                                        "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + System.getProperty("line.separator") +
-                                        "<bookstore>" + System.getProperty("line.separator") +
-                                        "  <book category=\"COOKING\">" + System.getProperty("line.separator") +
-                                        "    <title lang=\"en\">Everyday Italian</title>" + System.getProperty("line.separator") +
-                                        "    <author>Giada De Laurentiis</author>" + System.getProperty("line.separator") +
-                                        "    <year>2005</year>" + System.getProperty("line.separator") +
-                                        "    <price>30.00</price>" + System.getProperty("line.separator") +
-                                        "  </book>" + System.getProperty("line.separator") +
-                                        "  <book category=\"CHILDREN\">" + System.getProperty("line.separator") +
-                                        "    <title lang=\"en\">Harry Potter</title>" + System.getProperty("line.separator") +
-                                        "    <author>J K. Rowling</author>" + System.getProperty("line.separator") +
-                                        "    <year>2005</year>" + System.getProperty("line.separator") +
-                                        "    <price>29.99</price>" + System.getProperty("line.separator") +
-                                        "  </book>" + System.getProperty("line.separator") +
-                                        "  <book category=\"WEB\">" + System.getProperty("line.separator") +
-                                        "    <title lang=\"en\">Learning XML</title>" + System.getProperty("line.separator") +
-                                        "    <author>Erik T. Ray</author>" + System.getProperty("line.separator") +
-                                        "    <year>2003</year>" + System.getProperty("line.separator") +
-                                        "    <price>31.95</price>" + System.getProperty("line.separator") +
-                                        "  </book>" + System.getProperty("line.separator") +
+                                        "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + NL +
+                                        "<bookstore>" + NL +
+                                        "  <book category=\"COOKING\">" + NL +
+                                        "    <title lang=\"en\">Everyday Italian</title>" + NL +
+                                        "    <author>Giada De Laurentiis</author>" + NL +
+                                        "    <year>2005</year>" + NL +
+                                        "    <price>30.00</price>" + NL +
+                                        "  </book>" + NL +
+                                        "  <book category=\"CHILDREN\">" + NL +
+                                        "    <title lang=\"en\">Harry Potter</title>" + NL +
+                                        "    <author>J K. Rowling</author>" + NL +
+                                        "    <year>2005</year>" + NL +
+                                        "    <price>29.99</price>" + NL +
+                                        "  </book>" + NL +
+                                        "  <book category=\"WEB\">" + NL +
+                                        "    <title lang=\"en\">Learning XML</title>" + NL +
+                                        "    <author>Erik T. Ray</author>" + NL +
+                                        "    <year>2003</year>" + NL +
+                                        "    <price>31.95</price>" + NL +
+                                        "  </book>" + NL +
                                         "</bookstore>")),
                         headersToIgnore)
         );
@@ -881,9 +883,10 @@ public abstract class AbstractClientServerIntegrationTest {
     public void shouldReturnResponseByMatchingBodyWithXml() {
         // when
         mockServerClient.when(request().withBody(xml("" +
-                "<bookstore>" + System.getProperty("line.separator") +
-                "  <book nationality=\"ITALIAN\" category=\"COOKING\"><title lang=\"en\">Everyday Italian</title><author>Giada De Laurentiis</author><year>2005</year><price>30.00</price></book>" + System.getProperty("line.separator") +
-                "</bookstore>")), exactly(2)).respond(response().withBody("some_body"));
+                "<bookstore>" +
+                "<book nationality=\"ITALIAN\" category=\"COOKING\"><title lang=\"en\">Everyday Italian</title><author>Giada De Laurentiis</author><year>2005</year><price>30.00</price></book>" +
+                "</bookstore>")), exactly(2))
+                .respond(response().withBody("some_body"));
 
         // then
         // - in http
@@ -897,14 +900,13 @@ public abstract class AbstractClientServerIntegrationTest {
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
                                 .withBody(new StringBody("" +
-                                        "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + System.getProperty("line.separator") +
-                                        "<bookstore>" + System.getProperty("line.separator") +
-                                        "  <book category=\"COOKING\" nationality=\"ITALIAN\">" + System.getProperty("line.separator") +
-                                        "    <title lang=\"en\">Everyday Italian</title>" + System.getProperty("line.separator") +
-                                        "    <author>Giada De Laurentiis</author>" + System.getProperty("line.separator") +
-                                        "    <year>2005</year>" + System.getProperty("line.separator") +
-                                        "    <price>30.00</price>" + System.getProperty("line.separator") +
-                                        "  </book>" + System.getProperty("line.separator") +
+                                        "<bookstore>" + NL +
+                                        "   <book category=\"COOKING\" nationality=\"ITALIAN\">" + NL +
+                                        "      <title lang=\"en\">Everyday Italian</title>" + NL +
+                                        "      <author>Giada De Laurentiis</author>" + NL +
+                                        "      <year>2005</year>" + NL +
+                                        "      <price>30.00</price>" + NL +
+                                        "   </book>" + NL +
                                         "</bookstore>")),
                         headersToIgnore)
         );
@@ -920,14 +922,13 @@ public abstract class AbstractClientServerIntegrationTest {
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
                                 .withBody(new StringBody("" +
-                                        "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + System.getProperty("line.separator") +
-                                        "<bookstore>" + System.getProperty("line.separator") +
-                                        "  <book category=\"COOKING\" nationality=\"ITALIAN\">" + System.getProperty("line.separator") +
-                                        "    <title lang=\"en\">Everyday Italian</title>" + System.getProperty("line.separator") +
-                                        "    <author>Giada De Laurentiis</author>" + System.getProperty("line.separator") +
-                                        "    <year>2005</year>" + System.getProperty("line.separator") +
-                                        "    <price>30.00</price>" + System.getProperty("line.separator") +
-                                        "  </book>" + System.getProperty("line.separator") +
+                                        "<bookstore>" + NL +
+                                        "   <book category=\"COOKING\" nationality=\"ITALIAN\">" + NL +
+                                        "      <title lang=\"en\">Everyday Italian</title>" + NL +
+                                        "      <author>Giada De Laurentiis</author>" + NL +
+                                        "      <year>2005</year>" + NL +
+                                        "      <price>30.00</price>" + NL +
+                                        "   </book>" + NL +
                                         "</bookstore>")),
                         headersToIgnore)
         );
@@ -939,11 +940,11 @@ public abstract class AbstractClientServerIntegrationTest {
         mockServerClient
                 .when(
                         request()
-                                .withBody(json("{" + System.getProperty("line.separator") +
-                                        "    \"id\": 1," + System.getProperty("line.separator") +
-                                        "    \"name\": \"A green door\"," + System.getProperty("line.separator") +
-                                        "    \"price\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+                                .withBody(json("{" + NL +
+                                        "    \"id\": 1," + NL +
+                                        "    \"name\": \"A green door\"," + NL +
+                                        "    \"price\": 12.50," + NL +
+                                        "    \"tags\": [\"home\", \"green\"]" + NL +
                                         "}")),
                         exactly(2)
                 )
@@ -964,12 +965,12 @@ public abstract class AbstractClientServerIntegrationTest {
                         request()
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
-                                .withBody("{" + System.getProperty("line.separator") +
-                                        "    \"id\": 1," + System.getProperty("line.separator") +
-                                        "    \"extra ignored field\": \"some value\"," + System.getProperty("line.separator") +
-                                        "    \"name\": \"A green door\"," + System.getProperty("line.separator") +
-                                        "    \"price\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+                                .withBody("{" + NL +
+                                        "    \"id\": 1," + NL +
+                                        "    \"extra ignored field\": \"some value\"," + NL +
+                                        "    \"name\": \"A green door\"," + NL +
+                                        "    \"price\": 12.50," + NL +
+                                        "    \"tags\": [\"home\", \"green\"]" + NL +
                                         "}"),
                         headersToIgnore)
         );
@@ -984,12 +985,12 @@ public abstract class AbstractClientServerIntegrationTest {
                                 .withSecure(true)
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
-                                .withBody("{" + System.getProperty("line.separator") +
-                                        "    \"id\": 1," + System.getProperty("line.separator") +
-                                        "    \"extra ignored array\": [\"one\", \"two\"]," + System.getProperty("line.separator") +
-                                        "    \"name\": \"A green door\"," + System.getProperty("line.separator") +
-                                        "    \"price\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+                                .withBody("{" + NL +
+                                        "    \"id\": 1," + NL +
+                                        "    \"extra ignored array\": [\"one\", \"two\"]," + NL +
+                                        "    \"name\": \"A green door\"," + NL +
+                                        "    \"price\": 12.50," + NL +
+                                        "    \"tags\": [\"home\", \"green\"]" + NL +
                                         "}"),
                         headersToIgnore)
         );
@@ -1001,11 +1002,11 @@ public abstract class AbstractClientServerIntegrationTest {
         mockServerClient
                 .when(
                         request()
-                                .withBody(json("{" + System.getProperty("line.separator") +
-                                        "    \"ταυτότητα\": 1," + System.getProperty("line.separator") +
-                                        "    \"όνομα\": \"μια πράσινη πόρτα\"," + System.getProperty("line.separator") +
-                                        "    \"τιμή\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"ετικέτες\": [\"σπίτι\", \"πράσινος\"]" + System.getProperty("line.separator") +
+                                .withBody(json("{" + NL +
+                                        "    \"ταυτότητα\": 1," + NL +
+                                        "    \"όνομα\": \"μια πράσινη πόρτα\"," + NL +
+                                        "    \"τιμή\": 12.50," + NL +
+                                        "    \"ετικέτες\": [\"σπίτι\", \"πράσινος\"]" + NL +
                                         "}", Charsets.UTF_16, MatchType.ONLY_MATCHING_FIELDS)),
                         exactly(2)
                 )
@@ -1026,12 +1027,12 @@ public abstract class AbstractClientServerIntegrationTest {
                         request()
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
-                                .withBody(json("{" + System.getProperty("line.separator") +
-                                        "    \"ταυτότητα\": 1," + System.getProperty("line.separator") +
-                                        "    \"επιπλέον αγνοούνται τομέα\": \"κάποια αξία\"," + System.getProperty("line.separator") +
-                                        "    \"όνομα\": \"μια πράσινη πόρτα\"," + System.getProperty("line.separator") +
-                                        "    \"τιμή\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"ετικέτες\": [\"σπίτι\", \"πράσινος\"]" + System.getProperty("line.separator") +
+                                .withBody(json("{" + NL +
+                                        "    \"ταυτότητα\": 1," + NL +
+                                        "    \"επιπλέον αγνοούνται τομέα\": \"κάποια αξία\"," + NL +
+                                        "    \"όνομα\": \"μια πράσινη πόρτα\"," + NL +
+                                        "    \"τιμή\": 12.50," + NL +
+                                        "    \"ετικέτες\": [\"σπίτι\", \"πράσινος\"]" + NL +
                                         "}", Charsets.UTF_16, MatchType.ONLY_MATCHING_FIELDS)),
                         headersToIgnore)
         );
@@ -1046,12 +1047,12 @@ public abstract class AbstractClientServerIntegrationTest {
                                 .withSecure(true)
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
-                                .withBody(json("{" + System.getProperty("line.separator") +
-                                        "    \"ταυτότητα\": 1," + System.getProperty("line.separator") +
-                                        "    \"επιπλέον αγνοούνται σειρά\": [\"ένας\", \"δυο\"]," + System.getProperty("line.separator") +
-                                        "    \"όνομα\": \"μια πράσινη πόρτα\"," + System.getProperty("line.separator") +
-                                        "    \"τιμή\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"ετικέτες\": [\"σπίτι\", \"πράσινος\"]" + System.getProperty("line.separator") +
+                                .withBody(json("{" + NL +
+                                        "    \"ταυτότητα\": 1," + NL +
+                                        "    \"επιπλέον αγνοούνται σειρά\": [\"ένας\", \"δυο\"]," + NL +
+                                        "    \"όνομα\": \"μια πράσινη πόρτα\"," + NL +
+                                        "    \"τιμή\": 12.50," + NL +
+                                        "    \"ετικέτες\": [\"σπίτι\", \"πράσινος\"]" + NL +
                                         "}", Charsets.UTF_16, MatchType.ONLY_MATCHING_FIELDS)),
                         headersToIgnore)
         );
@@ -1063,11 +1064,11 @@ public abstract class AbstractClientServerIntegrationTest {
         mockServerClient
                 .when(
                         request()
-                                .withBody(json("{" + System.getProperty("line.separator") +
-                                        "    \"ταυτότητα\": 1," + System.getProperty("line.separator") +
-                                        "    \"όνομα\": \"μια πράσινη πόρτα\"," + System.getProperty("line.separator") +
-                                        "    \"τιμή\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"ετικέτες\": [\"σπίτι\", \"πράσινος\"]" + System.getProperty("line.separator") +
+                                .withBody(json("{" + NL +
+                                        "    \"ταυτότητα\": 1," + NL +
+                                        "    \"όνομα\": \"μια πράσινη πόρτα\"," + NL +
+                                        "    \"τιμή\": 12.50," + NL +
+                                        "    \"ετικέτες\": [\"σπίτι\", \"πράσινος\"]" + NL +
                                         "}", Charsets.UTF_16, MatchType.ONLY_MATCHING_FIELDS)),
                         exactly(2)
                 )
@@ -1089,12 +1090,12 @@ public abstract class AbstractClientServerIntegrationTest {
                                 .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.create("text", "plain").withCharset(Charsets.UTF_16).toString())
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
-                                .withBody(json("{" + System.getProperty("line.separator") +
-                                        "    \"ταυτότητα\": 1," + System.getProperty("line.separator") +
-                                        "    \"επιπλέον αγνοούνται τομέα\": \"κάποια αξία\"," + System.getProperty("line.separator") +
-                                        "    \"όνομα\": \"μια πράσινη πόρτα\"," + System.getProperty("line.separator") +
-                                        "    \"τιμή\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"ετικέτες\": [\"σπίτι\", \"πράσινος\"]" + System.getProperty("line.separator") +
+                                .withBody(json("{" + NL +
+                                        "    \"ταυτότητα\": 1," + NL +
+                                        "    \"επιπλέον αγνοούνται τομέα\": \"κάποια αξία\"," + NL +
+                                        "    \"όνομα\": \"μια πράσινη πόρτα\"," + NL +
+                                        "    \"τιμή\": 12.50," + NL +
+                                        "    \"ετικέτες\": [\"σπίτι\", \"πράσινος\"]" + NL +
                                         "}")),
                         headersToIgnore)
         );
@@ -1110,12 +1111,12 @@ public abstract class AbstractClientServerIntegrationTest {
                                 .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.create("text", "plain").withCharset(Charsets.UTF_16).toString())
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
-                                .withBody(json("{" + System.getProperty("line.separator") +
-                                        "    \"ταυτότητα\": 1," + System.getProperty("line.separator") +
-                                        "    \"επιπλέον αγνοούνται σειρά\": [\"ένας\", \"δυο\"]," + System.getProperty("line.separator") +
-                                        "    \"όνομα\": \"μια πράσινη πόρτα\"," + System.getProperty("line.separator") +
-                                        "    \"τιμή\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"ετικέτες\": [\"σπίτι\", \"πράσινος\"]" + System.getProperty("line.separator") +
+                                .withBody(json("{" + NL +
+                                        "    \"ταυτότητα\": 1," + NL +
+                                        "    \"επιπλέον αγνοούνται σειρά\": [\"ένας\", \"δυο\"]," + NL +
+                                        "    \"όνομα\": \"μια πράσινη πόρτα\"," + NL +
+                                        "    \"τιμή\": 12.50," + NL +
+                                        "    \"ετικέτες\": [\"σπίτι\", \"πράσινος\"]" + NL +
                                         "}")),
                         headersToIgnore)
         );
@@ -1127,11 +1128,11 @@ public abstract class AbstractClientServerIntegrationTest {
         mockServerClient
                 .when(
                         request()
-                                .withBody(json("{" + System.getProperty("line.separator") +
-                                        "    \"id\": 1," + System.getProperty("line.separator") +
-                                        "    \"name\": \"A green door\"," + System.getProperty("line.separator") +
-                                        "    \"price\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+                                .withBody(json("{" + NL +
+                                        "    \"id\": 1," + NL +
+                                        "    \"name\": \"A green door\"," + NL +
+                                        "    \"price\": 12.50," + NL +
+                                        "    \"tags\": [\"home\", \"green\"]" + NL +
                                         "}", MatchType.ONLY_MATCHING_FIELDS)),
                         exactly(2)
                 )
@@ -1148,12 +1149,12 @@ public abstract class AbstractClientServerIntegrationTest {
                         request()
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
-                                .withBody("{" + System.getProperty("line.separator") +
-                                        "    \"id\": 1," + System.getProperty("line.separator") +
-                                        "    \"extra field\": \"some value\"," + System.getProperty("line.separator") +
-                                        "    \"name\": \"A green door\"," + System.getProperty("line.separator") +
-                                        "    \"price\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+                                .withBody("{" + NL +
+                                        "    \"id\": 1," + NL +
+                                        "    \"extra field\": \"some value\"," + NL +
+                                        "    \"name\": \"A green door\"," + NL +
+                                        "    \"price\": 12.50," + NL +
+                                        "    \"tags\": [\"home\", \"green\"]" + NL +
                                         "}"),
                         headersToIgnore)
         );
@@ -1165,12 +1166,12 @@ public abstract class AbstractClientServerIntegrationTest {
                                 .withSecure(true)
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
-                                .withBody("{" + System.getProperty("line.separator") +
-                                        "    \"id\": 1," + System.getProperty("line.separator") +
-                                        "    \"extra field\": \"some value\"," + System.getProperty("line.separator") +
-                                        "    \"name\": \"A green door\"," + System.getProperty("line.separator") +
-                                        "    \"price\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+                                .withBody("{" + NL +
+                                        "    \"id\": 1," + NL +
+                                        "    \"extra field\": \"some value\"," + NL +
+                                        "    \"name\": \"A green door\"," + NL +
+                                        "    \"price\": 12.50," + NL +
+                                        "    \"tags\": [\"home\", \"green\"]" + NL +
                                         "}"),
                         headersToIgnore)
         );
@@ -1179,35 +1180,35 @@ public abstract class AbstractClientServerIntegrationTest {
     @Test
     public void shouldReturnResponseByMatchingBodyWithJsonSchema() {
         // when
-        mockServerClient.when(request().withBody(jsonSchema("{" + System.getProperty("line.separator") +
-                "    \"$schema\": \"http://json-schema.org/draft-04/schema#\"," + System.getProperty("line.separator") +
-                "    \"title\": \"Product\"," + System.getProperty("line.separator") +
-                "    \"description\": \"A product from Acme's catalog\"," + System.getProperty("line.separator") +
-                "    \"type\": \"object\"," + System.getProperty("line.separator") +
-                "    \"properties\": {" + System.getProperty("line.separator") +
-                "        \"id\": {" + System.getProperty("line.separator") +
-                "            \"description\": \"The unique identifier for a product\"," + System.getProperty("line.separator") +
-                "            \"type\": \"integer\"" + System.getProperty("line.separator") +
-                "        }," + System.getProperty("line.separator") +
-                "        \"name\": {" + System.getProperty("line.separator") +
-                "            \"description\": \"Name of the product\"," + System.getProperty("line.separator") +
-                "            \"type\": \"string\"" + System.getProperty("line.separator") +
-                "        }," + System.getProperty("line.separator") +
-                "        \"price\": {" + System.getProperty("line.separator") +
-                "            \"type\": \"number\"," + System.getProperty("line.separator") +
-                "            \"minimum\": 0," + System.getProperty("line.separator") +
-                "            \"exclusiveMinimum\": true" + System.getProperty("line.separator") +
-                "        }," + System.getProperty("line.separator") +
-                "        \"tags\": {" + System.getProperty("line.separator") +
-                "            \"type\": \"array\"," + System.getProperty("line.separator") +
-                "            \"items\": {" + System.getProperty("line.separator") +
-                "                \"type\": \"string\"" + System.getProperty("line.separator") +
-                "            }," + System.getProperty("line.separator") +
-                "            \"minItems\": 1," + System.getProperty("line.separator") +
-                "            \"uniqueItems\": true" + System.getProperty("line.separator") +
-                "        }" + System.getProperty("line.separator") +
-                "    }," + System.getProperty("line.separator") +
-                "    \"required\": [\"id\", \"name\", \"price\"]" + System.getProperty("line.separator") +
+        mockServerClient.when(request().withBody(jsonSchema("{" + NL +
+                "    \"$schema\": \"http://json-schema.org/draft-04/schema#\"," + NL +
+                "    \"title\": \"Product\"," + NL +
+                "    \"description\": \"A product from Acme's catalog\"," + NL +
+                "    \"type\": \"object\"," + NL +
+                "    \"properties\": {" + NL +
+                "        \"id\": {" + NL +
+                "            \"description\": \"The unique identifier for a product\"," + NL +
+                "            \"type\": \"integer\"" + NL +
+                "        }," + NL +
+                "        \"name\": {" + NL +
+                "            \"description\": \"Name of the product\"," + NL +
+                "            \"type\": \"string\"" + NL +
+                "        }," + NL +
+                "        \"price\": {" + NL +
+                "            \"type\": \"number\"," + NL +
+                "            \"minimum\": 0," + NL +
+                "            \"exclusiveMinimum\": true" + NL +
+                "        }," + NL +
+                "        \"tags\": {" + NL +
+                "            \"type\": \"array\"," + NL +
+                "            \"items\": {" + NL +
+                "                \"type\": \"string\"" + NL +
+                "            }," + NL +
+                "            \"minItems\": 1," + NL +
+                "            \"uniqueItems\": true" + NL +
+                "        }" + NL +
+                "    }," + NL +
+                "    \"required\": [\"id\", \"name\", \"price\"]" + NL +
                 "}")), exactly(2)).respond(response().withBody("some_body"));
 
         // then
@@ -1221,11 +1222,11 @@ public abstract class AbstractClientServerIntegrationTest {
                         request()
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
-                                .withBody("{" + System.getProperty("line.separator") +
-                                        "    \"id\": 1," + System.getProperty("line.separator") +
-                                        "    \"name\": \"A green door\"," + System.getProperty("line.separator") +
-                                        "    \"price\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+                                .withBody("{" + NL +
+                                        "    \"id\": 1," + NL +
+                                        "    \"name\": \"A green door\"," + NL +
+                                        "    \"price\": 12.50," + NL +
+                                        "    \"tags\": [\"home\", \"green\"]" + NL +
                                         "}"),
                         headersToIgnore)
         );
@@ -1240,11 +1241,11 @@ public abstract class AbstractClientServerIntegrationTest {
                                 .withSecure(true)
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
-                                .withBody("{" + System.getProperty("line.separator") +
-                                        "    \"id\": 1," + System.getProperty("line.separator") +
-                                        "    \"name\": \"A green door\"," + System.getProperty("line.separator") +
-                                        "    \"price\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+                                .withBody("{" + NL +
+                                        "    \"id\": 1," + NL +
+                                        "    \"name\": \"A green door\"," + NL +
+                                        "    \"price\": 12.50," + NL +
+                                        "    \"tags\": [\"home\", \"green\"]" + NL +
                                         "}"),
                         headersToIgnore)
         );
@@ -3030,11 +3031,11 @@ public abstract class AbstractClientServerIntegrationTest {
         mockServerClient
                 .when(
                         request()
-                                .withBody(Not.not(json("{" + System.getProperty("line.separator") +
-                                        "    \"id\": 1," + System.getProperty("line.separator") +
-                                        "    \"name\": \"A green door\"," + System.getProperty("line.separator") +
-                                        "    \"price\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+                                .withBody(Not.not(json("{" + NL +
+                                        "    \"id\": 1," + NL +
+                                        "    \"name\": \"A green door\"," + NL +
+                                        "    \"price\": 12.50," + NL +
+                                        "    \"tags\": [\"home\", \"green\"]" + NL +
                                         "}"))),
                         exactly(2)
                 )
@@ -3053,12 +3054,12 @@ public abstract class AbstractClientServerIntegrationTest {
                         request()
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
-                                .withBody("{" + System.getProperty("line.separator") +
-                                        "    \"id\": 1," + System.getProperty("line.separator") +
-                                        "    \"extra_ignored_field\": \"some value\"," + System.getProperty("line.separator") +
-                                        "    \"name\": \"A green door\"," + System.getProperty("line.separator") +
-                                        "    \"price\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+                                .withBody("{" + NL +
+                                        "    \"id\": 1," + NL +
+                                        "    \"extra_ignored_field\": \"some value\"," + NL +
+                                        "    \"name\": \"A green door\"," + NL +
+                                        "    \"price\": 12.50," + NL +
+                                        "    \"tags\": [\"home\", \"green\"]" + NL +
                                         "}"),
                         headersToIgnore)
         );
@@ -3071,12 +3072,12 @@ public abstract class AbstractClientServerIntegrationTest {
                                 .withSecure(true)
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
-                                .withBody("{" + System.getProperty("line.separator") +
-                                        "    \"id\": 1," + System.getProperty("line.separator") +
-                                        "    \"extra_ignored_array\": [\"one\", \"two\"]," + System.getProperty("line.separator") +
-                                        "    \"name\": \"A green door\"," + System.getProperty("line.separator") +
-                                        "    \"price\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+                                .withBody("{" + NL +
+                                        "    \"id\": 1," + NL +
+                                        "    \"extra_ignored_array\": [\"one\", \"two\"]," + NL +
+                                        "    \"name\": \"A green door\"," + NL +
+                                        "    \"price\": 12.50," + NL +
+                                        "    \"tags\": [\"home\", \"green\"]" + NL +
                                         "}"),
                         headersToIgnore)
         );
@@ -3098,26 +3099,26 @@ public abstract class AbstractClientServerIntegrationTest {
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
                                 .withBody(new StringBody("" +
-                                        "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + System.getProperty("line.separator") +
-                                        "<bookstore>" + System.getProperty("line.separator") +
-                                        "  <book category=\"COOKING\">" + System.getProperty("line.separator") +
-                                        "    <title lang=\"en\">Everyday Italian</title>" + System.getProperty("line.separator") +
-                                        "    <author>Giada De Laurentiis</author>" + System.getProperty("line.separator") +
-                                        "    <year>2005</year>" + System.getProperty("line.separator") +
-                                        "    <price>30.00</price>" + System.getProperty("line.separator") +
-                                        "  </book>" + System.getProperty("line.separator") +
-                                        "  <book category=\"CHILDREN\">" + System.getProperty("line.separator") +
-                                        "    <title lang=\"en\">Harry Potter</title>" + System.getProperty("line.separator") +
-                                        "    <author>J K. Rowling</author>" + System.getProperty("line.separator") +
-                                        "    <year>2005</year>" + System.getProperty("line.separator") +
-                                        "    <price>29.99</price>" + System.getProperty("line.separator") +
-                                        "  </book>" + System.getProperty("line.separator") +
-                                        "  <book category=\"WEB\">" + System.getProperty("line.separator") +
-                                        "    <title lang=\"en\">Learning XML</title>" + System.getProperty("line.separator") +
-                                        "    <author>Erik T. Ray</author>" + System.getProperty("line.separator") +
-                                        "    <year>2003</year>" + System.getProperty("line.separator") +
-                                        "    <price>31.95</price>" + System.getProperty("line.separator") +
-                                        "  </book>" + System.getProperty("line.separator") +
+                                        "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + NL +
+                                        "<bookstore>" + NL +
+                                        "  <book category=\"COOKING\">" + NL +
+                                        "    <title lang=\"en\">Everyday Italian</title>" + NL +
+                                        "    <author>Giada De Laurentiis</author>" + NL +
+                                        "    <year>2005</year>" + NL +
+                                        "    <price>30.00</price>" + NL +
+                                        "  </book>" + NL +
+                                        "  <book category=\"CHILDREN\">" + NL +
+                                        "    <title lang=\"en\">Harry Potter</title>" + NL +
+                                        "    <author>J K. Rowling</author>" + NL +
+                                        "    <year>2005</year>" + NL +
+                                        "    <price>29.99</price>" + NL +
+                                        "  </book>" + NL +
+                                        "  <book category=\"WEB\">" + NL +
+                                        "    <title lang=\"en\">Learning XML</title>" + NL +
+                                        "    <author>Erik T. Ray</author>" + NL +
+                                        "    <year>2003</year>" + NL +
+                                        "    <price>31.95</price>" + NL +
+                                        "  </book>" + NL +
                                         "</bookstore>")),
                         headersToIgnore)
         );
@@ -3131,26 +3132,26 @@ public abstract class AbstractClientServerIntegrationTest {
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
                                 .withBody(new StringBody("" +
-                                        "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + System.getProperty("line.separator") +
-                                        "<bookstore>" + System.getProperty("line.separator") +
-                                        "  <book category=\"COOKING\">" + System.getProperty("line.separator") +
-                                        "    <title lang=\"en\">Everyday Italian</title>" + System.getProperty("line.separator") +
-                                        "    <author>Giada De Laurentiis</author>" + System.getProperty("line.separator") +
-                                        "    <year>2005</year>" + System.getProperty("line.separator") +
-                                        "    <price>30.00</price>" + System.getProperty("line.separator") +
-                                        "  </book>" + System.getProperty("line.separator") +
-                                        "  <book category=\"CHILDREN\">" + System.getProperty("line.separator") +
-                                        "    <title lang=\"en\">Harry Potter</title>" + System.getProperty("line.separator") +
-                                        "    <author>J K. Rowling</author>" + System.getProperty("line.separator") +
-                                        "    <year>2005</year>" + System.getProperty("line.separator") +
-                                        "    <price>29.99</price>" + System.getProperty("line.separator") +
-                                        "  </book>" + System.getProperty("line.separator") +
-                                        "  <book category=\"WEB\">" + System.getProperty("line.separator") +
-                                        "    <title lang=\"en\">Learning XML</title>" + System.getProperty("line.separator") +
-                                        "    <author>Erik T. Ray</author>" + System.getProperty("line.separator") +
-                                        "    <year>2003</year>" + System.getProperty("line.separator") +
-                                        "    <price>31.95</price>" + System.getProperty("line.separator") +
-                                        "  </book>" + System.getProperty("line.separator") +
+                                        "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + NL +
+                                        "<bookstore>" + NL +
+                                        "  <book category=\"COOKING\">" + NL +
+                                        "    <title lang=\"en\">Everyday Italian</title>" + NL +
+                                        "    <author>Giada De Laurentiis</author>" + NL +
+                                        "    <year>2005</year>" + NL +
+                                        "    <price>30.00</price>" + NL +
+                                        "  </book>" + NL +
+                                        "  <book category=\"CHILDREN\">" + NL +
+                                        "    <title lang=\"en\">Harry Potter</title>" + NL +
+                                        "    <author>J K. Rowling</author>" + NL +
+                                        "    <year>2005</year>" + NL +
+                                        "    <price>29.99</price>" + NL +
+                                        "  </book>" + NL +
+                                        "  <book category=\"WEB\">" + NL +
+                                        "    <title lang=\"en\">Learning XML</title>" + NL +
+                                        "    <author>Erik T. Ray</author>" + NL +
+                                        "    <year>2003</year>" + NL +
+                                        "    <price>31.95</price>" + NL +
+                                        "  </book>" + NL +
                                         "</bookstore>")),
                         headersToIgnore)
         );
@@ -3160,14 +3161,14 @@ public abstract class AbstractClientServerIntegrationTest {
     public void shouldNotReturnResponseForNonMatchingXmlBody() {
         // when
         mockServerClient.when(request().withBody(xml("" +
-                "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + System.getProperty("line.separator") +
-                "<bookstore>" + System.getProperty("line.separator") +
-                "  <book category=\"COOKING\" nationality=\"ITALIAN\">" + System.getProperty("line.separator") +
-                "    <title lang=\"en\">Everyday Italian</title>" + System.getProperty("line.separator") +
-                "    <author>Giada De Laurentiis</author>" + System.getProperty("line.separator") +
-                "    <year>2005</year>" + System.getProperty("line.separator") +
-                "    <price>30.00</price>" + System.getProperty("line.separator") +
-                "  </book>" + System.getProperty("line.separator") +
+                "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + NL +
+                "<bookstore>" + NL +
+                "  <book category=\"COOKING\" nationality=\"ITALIAN\">" + NL +
+                "    <title lang=\"en\">Everyday Italian</title>" + NL +
+                "    <author>Giada De Laurentiis</author>" + NL +
+                "    <year>2005</year>" + NL +
+                "    <price>30.00</price>" + NL +
+                "  </book>" + NL +
                 "</bookstore>")), exactly(2)).respond(response().withBody("some_body"));
 
         // then
@@ -3181,14 +3182,14 @@ public abstract class AbstractClientServerIntegrationTest {
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
                                 .withBody(new StringBody("" +
-                                        "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + System.getProperty("line.separator") +
-                                        "<bookstore>" + System.getProperty("line.separator") +
-                                        "  <book category=\"COOKING\">" + System.getProperty("line.separator") +
-                                        "    <title lang=\"en\">Everyday Italian</title>" + System.getProperty("line.separator") +
-                                        "    <author>Giada De Laurentiis</author>" + System.getProperty("line.separator") +
-                                        "    <year>2005</year>" + System.getProperty("line.separator") +
-                                        "    <price>30.00</price>" + System.getProperty("line.separator") +
-                                        "  </book>" + System.getProperty("line.separator") +
+                                        "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + NL +
+                                        "<bookstore>" + NL +
+                                        "  <book category=\"COOKING\">" + NL +
+                                        "    <title lang=\"en\">Everyday Italian</title>" + NL +
+                                        "    <author>Giada De Laurentiis</author>" + NL +
+                                        "    <year>2005</year>" + NL +
+                                        "    <price>30.00</price>" + NL +
+                                        "  </book>" + NL +
                                         "</bookstore>")),
                         headersToIgnore)
         );
@@ -3202,14 +3203,14 @@ public abstract class AbstractClientServerIntegrationTest {
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
                                 .withBody(new StringBody("" +
-                                        "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + System.getProperty("line.separator") +
-                                        "<bookstore>" + System.getProperty("line.separator") +
-                                        "  <book category=\"COOKING\">" + System.getProperty("line.separator") +
-                                        "    <title lang=\"en\">Everyday Italian</title>" + System.getProperty("line.separator") +
-                                        "    <author>Giada De Laurentiis</author>" + System.getProperty("line.separator") +
-                                        "    <year>2005</year>" + System.getProperty("line.separator") +
-                                        "    <price>30.00</price>" + System.getProperty("line.separator") +
-                                        "  </book>" + System.getProperty("line.separator") +
+                                        "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + NL +
+                                        "<bookstore>" + NL +
+                                        "  <book category=\"COOKING\">" + NL +
+                                        "    <title lang=\"en\">Everyday Italian</title>" + NL +
+                                        "    <author>Giada De Laurentiis</author>" + NL +
+                                        "    <year>2005</year>" + NL +
+                                        "    <price>30.00</price>" + NL +
+                                        "  </book>" + NL +
                                         "</bookstore>")),
                         headersToIgnore)
         );
@@ -3218,11 +3219,11 @@ public abstract class AbstractClientServerIntegrationTest {
     @Test
     public void shouldNotReturnResponseForNonMatchingJsonBody() {
         // when
-        mockServerClient.when(request().withBody(json("{" + System.getProperty("line.separator") +
-                "    \"id\": 1," + System.getProperty("line.separator") +
-                "    \"name\": \"A green door\"," + System.getProperty("line.separator") +
-                "    \"price\": 12.50," + System.getProperty("line.separator") +
-                "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+        mockServerClient.when(request().withBody(json("{" + NL +
+                "    \"id\": 1," + NL +
+                "    \"name\": \"A green door\"," + NL +
+                "    \"price\": 12.50," + NL +
+                "    \"tags\": [\"home\", \"green\"]" + NL +
                 "}")), exactly(2)).respond(response().withBody("some_body"));
 
         // then
@@ -3234,11 +3235,11 @@ public abstract class AbstractClientServerIntegrationTest {
                         request()
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
-                                .withBody("{" + System.getProperty("line.separator") +
-                                        "    \"id\": 1," + System.getProperty("line.separator") +
-                                        "    \"name\": \"---- XXXX WRONG VALUE XXXX ----\"," + System.getProperty("line.separator") +
-                                        "    \"price\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+                                .withBody("{" + NL +
+                                        "    \"id\": 1," + NL +
+                                        "    \"name\": \"---- XXXX WRONG VALUE XXXX ----\"," + NL +
+                                        "    \"price\": 12.50," + NL +
+                                        "    \"tags\": [\"home\", \"green\"]" + NL +
                                         "}"),
                         headersToIgnore)
         );
@@ -3251,11 +3252,11 @@ public abstract class AbstractClientServerIntegrationTest {
                                 .withSecure(true)
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
-                                .withBody("{" + System.getProperty("line.separator") +
-                                        "    \"id\": 1," + System.getProperty("line.separator") +
-                                        "    \"name\": \"---- XXXX WRONG VALUE XXXX ----\"," + System.getProperty("line.separator") +
-                                        "    \"price\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+                                .withBody("{" + NL +
+                                        "    \"id\": 1," + NL +
+                                        "    \"name\": \"---- XXXX WRONG VALUE XXXX ----\"," + NL +
+                                        "    \"price\": 12.50," + NL +
+                                        "    \"tags\": [\"home\", \"green\"]" + NL +
                                         "}"),
                         headersToIgnore)
         );
@@ -3267,11 +3268,11 @@ public abstract class AbstractClientServerIntegrationTest {
         mockServerClient
                 .when(
                         request()
-                                .withBody(json("{" + System.getProperty("line.separator") +
-                                        "    \"id\": 1," + System.getProperty("line.separator") +
-                                        "    \"name\": \"A green door\"," + System.getProperty("line.separator") +
-                                        "    \"price\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+                                .withBody(json("{" + NL +
+                                        "    \"id\": 1," + NL +
+                                        "    \"name\": \"A green door\"," + NL +
+                                        "    \"price\": 12.50," + NL +
+                                        "    \"tags\": [\"home\", \"green\"]" + NL +
                                         "}", MatchType.STRICT)),
                         exactly(2))
                 .respond(
@@ -3288,12 +3289,12 @@ public abstract class AbstractClientServerIntegrationTest {
                         request()
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
-                                .withBody("{" + System.getProperty("line.separator") +
-                                        "    \"id\": 1," + System.getProperty("line.separator") +
-                                        "    \"extra field\": \"some value\"," + System.getProperty("line.separator") +
-                                        "    \"name\": \"A green door\"," + System.getProperty("line.separator") +
-                                        "    \"price\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+                                .withBody("{" + NL +
+                                        "    \"id\": 1," + NL +
+                                        "    \"extra field\": \"some value\"," + NL +
+                                        "    \"name\": \"A green door\"," + NL +
+                                        "    \"price\": 12.50," + NL +
+                                        "    \"tags\": [\"home\", \"green\"]" + NL +
                                         "}"),
                         headersToIgnore)
         );
@@ -3306,12 +3307,12 @@ public abstract class AbstractClientServerIntegrationTest {
                                 .withSecure(true)
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
-                                .withBody("{" + System.getProperty("line.separator") +
-                                        "    \"id\": 1," + System.getProperty("line.separator") +
-                                        "    \"extra field\": \"some value\"," + System.getProperty("line.separator") +
-                                        "    \"name\": \"A green door\"," + System.getProperty("line.separator") +
-                                        "    \"price\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+                                .withBody("{" + NL +
+                                        "    \"id\": 1," + NL +
+                                        "    \"extra field\": \"some value\"," + NL +
+                                        "    \"name\": \"A green door\"," + NL +
+                                        "    \"price\": 12.50," + NL +
+                                        "    \"tags\": [\"home\", \"green\"]" + NL +
                                         "}"),
                         headersToIgnore)
         );
@@ -3320,35 +3321,35 @@ public abstract class AbstractClientServerIntegrationTest {
     @Test
     public void shouldNotReturnResponseForNonMatchingJsonSchema() {
         // when
-        mockServerClient.when(request().withBody(jsonSchema("{" + System.getProperty("line.separator") +
-                "    \"$schema\": \"http://json-schema.org/draft-04/schema#\"," + System.getProperty("line.separator") +
-                "    \"title\": \"Product\"," + System.getProperty("line.separator") +
-                "    \"description\": \"A product from Acme's catalog\"," + System.getProperty("line.separator") +
-                "    \"type\": \"object\"," + System.getProperty("line.separator") +
-                "    \"properties\": {" + System.getProperty("line.separator") +
-                "        \"id\": {" + System.getProperty("line.separator") +
-                "            \"description\": \"The unique identifier for a product\"," + System.getProperty("line.separator") +
-                "            \"type\": \"integer\"" + System.getProperty("line.separator") +
-                "        }," + System.getProperty("line.separator") +
-                "        \"name\": {" + System.getProperty("line.separator") +
-                "            \"description\": \"Name of the product\"," + System.getProperty("line.separator") +
-                "            \"type\": \"string\"" + System.getProperty("line.separator") +
-                "        }," + System.getProperty("line.separator") +
-                "        \"price\": {" + System.getProperty("line.separator") +
-                "            \"type\": \"number\"," + System.getProperty("line.separator") +
-                "            \"minimum\": 0," + System.getProperty("line.separator") +
-                "            \"exclusiveMinimum\": true" + System.getProperty("line.separator") +
-                "        }," + System.getProperty("line.separator") +
-                "        \"tags\": {" + System.getProperty("line.separator") +
-                "            \"type\": \"array\"," + System.getProperty("line.separator") +
-                "            \"items\": {" + System.getProperty("line.separator") +
-                "                \"type\": \"string\"" + System.getProperty("line.separator") +
-                "            }," + System.getProperty("line.separator") +
-                "            \"minItems\": 1," + System.getProperty("line.separator") +
-                "            \"uniqueItems\": true" + System.getProperty("line.separator") +
-                "        }" + System.getProperty("line.separator") +
-                "    }," + System.getProperty("line.separator") +
-                "    \"required\": [\"id\", \"name\", \"price\"]" + System.getProperty("line.separator") +
+        mockServerClient.when(request().withBody(jsonSchema("{" + NL +
+                "    \"$schema\": \"http://json-schema.org/draft-04/schema#\"," + NL +
+                "    \"title\": \"Product\"," + NL +
+                "    \"description\": \"A product from Acme's catalog\"," + NL +
+                "    \"type\": \"object\"," + NL +
+                "    \"properties\": {" + NL +
+                "        \"id\": {" + NL +
+                "            \"description\": \"The unique identifier for a product\"," + NL +
+                "            \"type\": \"integer\"" + NL +
+                "        }," + NL +
+                "        \"name\": {" + NL +
+                "            \"description\": \"Name of the product\"," + NL +
+                "            \"type\": \"string\"" + NL +
+                "        }," + NL +
+                "        \"price\": {" + NL +
+                "            \"type\": \"number\"," + NL +
+                "            \"minimum\": 0," + NL +
+                "            \"exclusiveMinimum\": true" + NL +
+                "        }," + NL +
+                "        \"tags\": {" + NL +
+                "            \"type\": \"array\"," + NL +
+                "            \"items\": {" + NL +
+                "                \"type\": \"string\"" + NL +
+                "            }," + NL +
+                "            \"minItems\": 1," + NL +
+                "            \"uniqueItems\": true" + NL +
+                "        }" + NL +
+                "    }," + NL +
+                "    \"required\": [\"id\", \"name\", \"price\"]" + NL +
                 "}")), exactly(2)).respond(response().withBody("some_body"));
 
         // then
@@ -3360,11 +3361,11 @@ public abstract class AbstractClientServerIntegrationTest {
                         request()
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
-                                .withBody("{" + System.getProperty("line.separator") +
-                                        "    \"id\": 1," + System.getProperty("line.separator") +
-                                        "    \"wrong field name\": \"A green door\"," + System.getProperty("line.separator") +
-                                        "    \"price\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+                                .withBody("{" + NL +
+                                        "    \"id\": 1," + NL +
+                                        "    \"wrong field name\": \"A green door\"," + NL +
+                                        "    \"price\": 12.50," + NL +
+                                        "    \"tags\": [\"home\", \"green\"]" + NL +
                                         "}"),
                         headersToIgnore)
         );
@@ -3377,11 +3378,11 @@ public abstract class AbstractClientServerIntegrationTest {
                                 .withSecure(true)
                                 .withPath(calculatePath("some_path"))
                                 .withMethod("POST")
-                                .withBody("{" + System.getProperty("line.separator") +
-                                        "    \"id\": 1," + System.getProperty("line.separator") +
-                                        "    \"name\": \"A green door\"," + System.getProperty("line.separator") +
-                                        "    \"wrong field name\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+                                .withBody("{" + NL +
+                                        "    \"id\": 1," + NL +
+                                        "    \"name\": \"A green door\"," + NL +
+                                        "    \"wrong field name\": 12.50," + NL +
+                                        "    \"tags\": [\"home\", \"green\"]" + NL +
                                         "}"),
                         headersToIgnore)
         );
@@ -4306,11 +4307,11 @@ public abstract class AbstractClientServerIntegrationTest {
                     .withPath(calculatePath("some_path")), VerificationTimes.atLeast(2));
             fail();
         } catch (AssertionError ae) {
-            assertThat(ae.getMessage(), startsWith("Request not found at least 2 times, expected:<{" + System.getProperty("line.separator") +
-                    "  \"path\" : \"" + calculatePath("some_path") + "\"" + System.getProperty("line.separator") +
-                    "}> but was:<{" + System.getProperty("line.separator") +
-                    "  \"method\" : \"GET\"," + System.getProperty("line.separator") +
-                    "  \"path\" : \"" + calculatePath("some_path") + "\"," + System.getProperty("line.separator")));
+            assertThat(ae.getMessage(), startsWith("Request not found at least 2 times, expected:<{" + NL +
+                    "  \"path\" : \"" + calculatePath("some_path") + "\"" + NL +
+                    "}> but was:<{" + NL +
+                    "  \"method\" : \"GET\"," + NL +
+                    "  \"path\" : \"" + calculatePath("some_path") + "\"," + NL));
         }
     }
 
@@ -4335,11 +4336,11 @@ public abstract class AbstractClientServerIntegrationTest {
                     .withPath(calculatePath("some_path")), VerificationTimes.exactly(0));
             fail();
         } catch (AssertionError ae) {
-            assertThat(ae.getMessage(), startsWith("Request not found exactly 0 times, expected:<{" + System.getProperty("line.separator") +
-                    "  \"path\" : \"" + calculatePath("some_path") + "\"" + System.getProperty("line.separator") +
-                    "}> but was:<{" + System.getProperty("line.separator") +
-                    "  \"method\" : \"GET\"," + System.getProperty("line.separator") +
-                    "  \"path\" : \"" + calculatePath("some_path") + "\"," + System.getProperty("line.separator")));
+            assertThat(ae.getMessage(), startsWith("Request not found exactly 0 times, expected:<{" + NL +
+                    "  \"path\" : \"" + calculatePath("some_path") + "\"" + NL +
+                    "}> but was:<{" + NL +
+                    "  \"method\" : \"GET\"," + NL +
+                    "  \"path\" : \"" + calculatePath("some_path") + "\"," + NL));
         }
     }
 
@@ -4364,11 +4365,11 @@ public abstract class AbstractClientServerIntegrationTest {
                     .withPath(calculatePath("some_other_path")), VerificationTimes.exactly(2));
             fail();
         } catch (AssertionError ae) {
-            assertThat(ae.getMessage(), startsWith("Request not found exactly 2 times, expected:<{" + System.getProperty("line.separator") +
-                    "  \"path\" : \"" + calculatePath("some_other_path") + "\"" + System.getProperty("line.separator") +
-                    "}> but was:<{" + System.getProperty("line.separator") +
-                    "  \"method\" : \"GET\"," + System.getProperty("line.separator") +
-                    "  \"path\" : \"" + calculatePath("some_path") + "\"," + System.getProperty("line.separator")));
+            assertThat(ae.getMessage(), startsWith("Request not found exactly 2 times, expected:<{" + NL +
+                    "  \"path\" : \"" + calculatePath("some_other_path") + "\"" + NL +
+                    "}> but was:<{" + NL +
+                    "  \"method\" : \"GET\"," + NL +
+                    "  \"path\" : \"" + calculatePath("some_path") + "\"," + NL));
         }
     }
 
@@ -4401,9 +4402,9 @@ public abstract class AbstractClientServerIntegrationTest {
             mockServerClient.verifyZeroInteractions();
             fail();
         } catch (AssertionError ae) {
-            assertThat(ae.getMessage(), startsWith("Request not found exactly 0 times, expected:<{ }> but was:<{" + System.getProperty("line.separator") +
-                    "  \"method\" : \"GET\"," + System.getProperty("line.separator") +
-                    "  \"path\" : \"" + calculatePath("some_path") + "\"," + System.getProperty("line.separator")));
+            assertThat(ae.getMessage(), startsWith("Request not found exactly 0 times, expected:<{ }> but was:<{" + NL +
+                    "  \"method\" : \"GET\"," + NL +
+                    "  \"path\" : \"" + calculatePath("some_path") + "\"," + NL));
         }
     }
 
@@ -4433,12 +4434,12 @@ public abstract class AbstractClientServerIntegrationTest {
             );
             fail();
         } catch (AssertionError ae) {
-            assertThat(ae.getMessage(), startsWith("Request not found at least once, expected:<{" + System.getProperty("line.separator") +
-                    "  \"path\" : \"" + calculatePath("some_path") + "\"," + System.getProperty("line.separator") +
-                    "  \"secure\" : true" + System.getProperty("line.separator") +
-                    "}> but was:<{" + System.getProperty("line.separator") +
-                    "  \"method\" : \"GET\"," + System.getProperty("line.separator") +
-                    "  \"path\" : \"" + calculatePath("some_path") + "\"," + System.getProperty("line.separator")));
+            assertThat(ae.getMessage(), startsWith("Request not found at least once, expected:<{" + NL +
+                    "  \"path\" : \"" + calculatePath("some_path") + "\"," + NL +
+                    "  \"secure\" : true" + NL +
+                    "}> but was:<{" + NL +
+                    "  \"method\" : \"GET\"," + NL +
+                    "  \"path\" : \"" + calculatePath("some_path") + "\"," + NL));
         }
 
         // - in https
@@ -4462,12 +4463,12 @@ public abstract class AbstractClientServerIntegrationTest {
             );
             fail();
         } catch (AssertionError ae) {
-            assertThat(ae.getMessage(), startsWith("Request not found at least once, expected:<{" + System.getProperty("line.separator") +
-                    "  \"path\" : \"" + calculatePath("some_secure_path") + "\"," + System.getProperty("line.separator") +
-                    "  \"secure\" : false" + System.getProperty("line.separator") +
-                    "}> but was:<[ {" + System.getProperty("line.separator") +
-                    "  \"method\" : \"GET\"," + System.getProperty("line.separator") +
-                    "  \"path\" : \"" + calculatePath("some_path") + "\"," + System.getProperty("line.separator")));
+            assertThat(ae.getMessage(), startsWith("Request not found at least once, expected:<{" + NL +
+                    "  \"path\" : \"" + calculatePath("some_secure_path") + "\"," + NL +
+                    "  \"secure\" : false" + NL +
+                    "}> but was:<[ {" + NL +
+                    "  \"method\" : \"GET\"," + NL +
+                    "  \"path\" : \"" + calculatePath("some_path") + "\"," + NL));
         }
 
     }
@@ -4656,35 +4657,35 @@ public abstract class AbstractClientServerIntegrationTest {
             mockServerClient.verify(request(calculatePath("some_path_two")), request(calculatePath("some_path_one")));
             fail();
         } catch (AssertionError ae) {
-            assertThat(ae.getMessage(), startsWith("Request sequence not found, expected:<[ {" + System.getProperty("line.separator") +
-                    "  \"path\" : \"" + calculatePath("some_path_two") + "\"" + System.getProperty("line.separator") +
-                    "}, {" + System.getProperty("line.separator") +
-                    "  \"path\" : \"" + calculatePath("some_path_one") + "\"" + System.getProperty("line.separator") +
-                    "} ]> but was:<[ {" + System.getProperty("line.separator") +
-                    "  \"method\" : \"GET\"," + System.getProperty("line.separator") +
-                    "  \"path\" : \"" + calculatePath("some_path_one") + "\"," + System.getProperty("line.separator")));
+            assertThat(ae.getMessage(), startsWith("Request sequence not found, expected:<[ {" + NL +
+                    "  \"path\" : \"" + calculatePath("some_path_two") + "\"" + NL +
+                    "}, {" + NL +
+                    "  \"path\" : \"" + calculatePath("some_path_one") + "\"" + NL +
+                    "} ]> but was:<[ {" + NL +
+                    "  \"method\" : \"GET\"," + NL +
+                    "  \"path\" : \"" + calculatePath("some_path_one") + "\"," + NL));
         }
         try {
             mockServerClient.verify(request(calculatePath("some_path_three")), request(calculatePath("some_path_two")));
             fail();
         } catch (AssertionError ae) {
-            assertThat(ae.getMessage(), startsWith("Request sequence not found, expected:<[ {" + System.getProperty("line.separator") +
-                    "  \"path\" : \"" + calculatePath("some_path_three") + "\"" + System.getProperty("line.separator") +
-                    "}, {" + System.getProperty("line.separator") +
-                    "  \"path\" : \"" + calculatePath("some_path_two") + "\"" + System.getProperty("line.separator") +
-                    "} ]> but was:<[ {" + System.getProperty("line.separator") +
-                    "  \"method\" : \"GET\"," + System.getProperty("line.separator") +
-                    "  \"path\" : \"" + calculatePath("some_path_one") + "\"," + System.getProperty("line.separator")));
+            assertThat(ae.getMessage(), startsWith("Request sequence not found, expected:<[ {" + NL +
+                    "  \"path\" : \"" + calculatePath("some_path_three") + "\"" + NL +
+                    "}, {" + NL +
+                    "  \"path\" : \"" + calculatePath("some_path_two") + "\"" + NL +
+                    "} ]> but was:<[ {" + NL +
+                    "  \"method\" : \"GET\"," + NL +
+                    "  \"path\" : \"" + calculatePath("some_path_one") + "\"," + NL));
         }
         try {
             mockServerClient.verify(request(calculatePath("some_path_four")));
             fail();
         } catch (AssertionError ae) {
-            assertThat(ae.getMessage(), startsWith("Request sequence not found, expected:<[ {" + System.getProperty("line.separator") +
-                    "  \"path\" : \"" + calculatePath("some_path_four") + "\"" + System.getProperty("line.separator") +
-                    "} ]> but was:<[ {" + System.getProperty("line.separator") +
-                    "  \"method\" : \"GET\"," + System.getProperty("line.separator") +
-                    "  \"path\" : \"" + calculatePath("some_path_one") + "\"," + System.getProperty("line.separator")));
+            assertThat(ae.getMessage(), startsWith("Request sequence not found, expected:<[ {" + NL +
+                    "  \"path\" : \"" + calculatePath("some_path_four") + "\"" + NL +
+                    "} ]> but was:<[ {" + NL +
+                    "  \"method\" : \"GET\"," + NL +
+                    "  \"path\" : \"" + calculatePath("some_path_one") + "\"," + NL));
         }
     }
 
@@ -4885,26 +4886,26 @@ public abstract class AbstractClientServerIntegrationTest {
 
         // and
         StringBody xmlBody = new StringBody("" +
-                "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + System.getProperty("line.separator") +
-                "<bookstore>" + System.getProperty("line.separator") +
-                "  <book category=\"COOKING\">" + System.getProperty("line.separator") +
-                "    <title lang=\"en\">Everyday Italian</title>" + System.getProperty("line.separator") +
-                "    <author>Giada De Laurentiis</author>" + System.getProperty("line.separator") +
-                "    <year>2005</year>" + System.getProperty("line.separator") +
-                "    <price>30.00</price>" + System.getProperty("line.separator") +
-                "  </book>" + System.getProperty("line.separator") +
-                "  <book category=\"CHILDREN\">" + System.getProperty("line.separator") +
-                "    <title lang=\"en\">Harry Potter</title>" + System.getProperty("line.separator") +
-                "    <author>J K. Rowling</author>" + System.getProperty("line.separator") +
-                "    <year>2006</year>" + System.getProperty("line.separator") +
-                "    <price>29.99</price>" + System.getProperty("line.separator") +
-                "  </book>" + System.getProperty("line.separator") +
-                "  <book category=\"WEB\">" + System.getProperty("line.separator") +
-                "    <title lang=\"en\">Learning XML</title>" + System.getProperty("line.separator") +
-                "    <author>Erik T. Ray</author>" + System.getProperty("line.separator") +
-                "    <year>2003</year>" + System.getProperty("line.separator") +
-                "    <price>31.95</price>" + System.getProperty("line.separator") +
-                "  </book>" + System.getProperty("line.separator") +
+                "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + NL +
+                "<bookstore>" + NL +
+                "  <book category=\"COOKING\">" + NL +
+                "    <title lang=\"en\">Everyday Italian</title>" + NL +
+                "    <author>Giada De Laurentiis</author>" + NL +
+                "    <year>2005</year>" + NL +
+                "    <price>30.00</price>" + NL +
+                "  </book>" + NL +
+                "  <book category=\"CHILDREN\">" + NL +
+                "    <title lang=\"en\">Harry Potter</title>" + NL +
+                "    <author>J K. Rowling</author>" + NL +
+                "    <year>2006</year>" + NL +
+                "    <price>29.99</price>" + NL +
+                "  </book>" + NL +
+                "  <book category=\"WEB\">" + NL +
+                "    <title lang=\"en\">Learning XML</title>" + NL +
+                "    <author>Erik T. Ray</author>" + NL +
+                "    <year>2003</year>" + NL +
+                "    <price>31.95</price>" + NL +
+                "  </book>" + NL +
                 "</bookstore>");
 
         // then
@@ -4968,65 +4969,65 @@ public abstract class AbstractClientServerIntegrationTest {
     @Test
     public void shouldClearExpectationsWithJsonSchemaBody() {
         // given
-        JsonSchemaBody jsonSchemaBodyOne = jsonSchema("{" + System.getProperty("line.separator") +
-                "    \"$schema\": \"http://json-schema.org/draft-04/schema#\"," + System.getProperty("line.separator") +
-                "    \"title\": \"Product\"," + System.getProperty("line.separator") +
-                "    \"description\": \"A product from Acme's catalog\"," + System.getProperty("line.separator") +
-                "    \"type\": \"object\"," + System.getProperty("line.separator") +
-                "    \"properties\": {" + System.getProperty("line.separator") +
-                "        \"id\": {" + System.getProperty("line.separator") +
-                "            \"description\": \"The unique identifier for a product\"," + System.getProperty("line.separator") +
-                "            \"type\": \"integer\"" + System.getProperty("line.separator") +
-                "        }," + System.getProperty("line.separator") +
-                "        \"name\": {" + System.getProperty("line.separator") +
-                "            \"description\": \"Name of the product\"," + System.getProperty("line.separator") +
-                "            \"type\": \"string\"" + System.getProperty("line.separator") +
-                "        }," + System.getProperty("line.separator") +
-                "        \"price\": {" + System.getProperty("line.separator") +
-                "            \"type\": \"number\"," + System.getProperty("line.separator") +
-                "            \"minimum\": 0," + System.getProperty("line.separator") +
-                "            \"exclusiveMinimum\": true" + System.getProperty("line.separator") +
-                "        }," + System.getProperty("line.separator") +
-                "        \"tags\": {" + System.getProperty("line.separator") +
-                "            \"type\": \"array\"," + System.getProperty("line.separator") +
-                "            \"items\": {" + System.getProperty("line.separator") +
-                "                \"type\": \"string\"" + System.getProperty("line.separator") +
-                "            }," + System.getProperty("line.separator") +
-                "            \"minItems\": 1," + System.getProperty("line.separator") +
-                "            \"uniqueItems\": true" + System.getProperty("line.separator") +
-                "        }" + System.getProperty("line.separator") +
-                "    }," + System.getProperty("line.separator") +
-                "    \"required\": [\"id\", \"name\", \"price\"]" + System.getProperty("line.separator") +
+        JsonSchemaBody jsonSchemaBodyOne = jsonSchema("{" + NL +
+                "    \"$schema\": \"http://json-schema.org/draft-04/schema#\"," + NL +
+                "    \"title\": \"Product\"," + NL +
+                "    \"description\": \"A product from Acme's catalog\"," + NL +
+                "    \"type\": \"object\"," + NL +
+                "    \"properties\": {" + NL +
+                "        \"id\": {" + NL +
+                "            \"description\": \"The unique identifier for a product\"," + NL +
+                "            \"type\": \"integer\"" + NL +
+                "        }," + NL +
+                "        \"name\": {" + NL +
+                "            \"description\": \"Name of the product\"," + NL +
+                "            \"type\": \"string\"" + NL +
+                "        }," + NL +
+                "        \"price\": {" + NL +
+                "            \"type\": \"number\"," + NL +
+                "            \"minimum\": 0," + NL +
+                "            \"exclusiveMinimum\": true" + NL +
+                "        }," + NL +
+                "        \"tags\": {" + NL +
+                "            \"type\": \"array\"," + NL +
+                "            \"items\": {" + NL +
+                "                \"type\": \"string\"" + NL +
+                "            }," + NL +
+                "            \"minItems\": 1," + NL +
+                "            \"uniqueItems\": true" + NL +
+                "        }" + NL +
+                "    }," + NL +
+                "    \"required\": [\"id\", \"name\", \"price\"]" + NL +
                 "}");
-        JsonSchemaBody jsonSchemaBodyTwo = jsonSchema("{" + System.getProperty("line.separator") +
-                "    \"$schema\": \"http://json-schema.org/draft-04/schema#\"," + System.getProperty("line.separator") +
-                "    \"title\": \"Product\"," + System.getProperty("line.separator") +
-                "    \"description\": \"A product from Acme's catalog\"," + System.getProperty("line.separator") +
-                "    \"type\": \"object\"," + System.getProperty("line.separator") +
-                "    \"properties\": {" + System.getProperty("line.separator") +
-                "        \"id\": {" + System.getProperty("line.separator") +
-                "            \"description\": \"The unique identifier for a product\"," + System.getProperty("line.separator") +
-                "            \"type\": \"integer\"" + System.getProperty("line.separator") +
-                "        }," + System.getProperty("line.separator") +
-                "        \"name\": {" + System.getProperty("line.separator") +
-                "            \"description\": \"Name of the product\"," + System.getProperty("line.separator") +
-                "            \"type\": \"string\"" + System.getProperty("line.separator") +
-                "        }," + System.getProperty("line.separator") +
-                "        \"price\": {" + System.getProperty("line.separator") +
-                "            \"type\": \"number\"," + System.getProperty("line.separator") +
-                "            \"minimum\": 10," + System.getProperty("line.separator") +
-                "            \"exclusiveMinimum\": true" + System.getProperty("line.separator") +
-                "        }," + System.getProperty("line.separator") +
-                "        \"tags\": {" + System.getProperty("line.separator") +
-                "            \"type\": \"array\"," + System.getProperty("line.separator") +
-                "            \"items\": {" + System.getProperty("line.separator") +
-                "                \"type\": \"string\"" + System.getProperty("line.separator") +
-                "            }," + System.getProperty("line.separator") +
-                "            \"minItems\": 1," + System.getProperty("line.separator") +
-                "            \"uniqueItems\": true" + System.getProperty("line.separator") +
-                "        }" + System.getProperty("line.separator") +
-                "    }," + System.getProperty("line.separator") +
-                "    \"required\": [\"id\", \"name\", \"price\"]" + System.getProperty("line.separator") +
+        JsonSchemaBody jsonSchemaBodyTwo = jsonSchema("{" + NL +
+                "    \"$schema\": \"http://json-schema.org/draft-04/schema#\"," + NL +
+                "    \"title\": \"Product\"," + NL +
+                "    \"description\": \"A product from Acme's catalog\"," + NL +
+                "    \"type\": \"object\"," + NL +
+                "    \"properties\": {" + NL +
+                "        \"id\": {" + NL +
+                "            \"description\": \"The unique identifier for a product\"," + NL +
+                "            \"type\": \"integer\"" + NL +
+                "        }," + NL +
+                "        \"name\": {" + NL +
+                "            \"description\": \"Name of the product\"," + NL +
+                "            \"type\": \"string\"" + NL +
+                "        }," + NL +
+                "        \"price\": {" + NL +
+                "            \"type\": \"number\"," + NL +
+                "            \"minimum\": 10," + NL +
+                "            \"exclusiveMinimum\": true" + NL +
+                "        }," + NL +
+                "        \"tags\": {" + NL +
+                "            \"type\": \"array\"," + NL +
+                "            \"items\": {" + NL +
+                "                \"type\": \"string\"" + NL +
+                "            }," + NL +
+                "            \"minItems\": 1," + NL +
+                "            \"uniqueItems\": true" + NL +
+                "        }" + NL +
+                "    }," + NL +
+                "    \"required\": [\"id\", \"name\", \"price\"]" + NL +
                 "}");
         mockServerClient
                 .when(
@@ -5055,11 +5056,11 @@ public abstract class AbstractClientServerIntegrationTest {
                         .withBody("some_body1"),
                 makeRequest(
                         request()
-                                .withBody("{" + System.getProperty("line.separator") +
-                                        "    \"id\": 1," + System.getProperty("line.separator") +
-                                        "    \"name\": \"A green door\"," + System.getProperty("line.separator") +
-                                        "    \"price\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+                                .withBody("{" + NL +
+                                        "    \"id\": 1," + NL +
+                                        "    \"name\": \"A green door\"," + NL +
+                                        "    \"price\": 12.50," + NL +
+                                        "    \"tags\": [\"home\", \"green\"]" + NL +
                                         "}"),
                         headersToIgnore)
         );
@@ -5093,11 +5094,11 @@ public abstract class AbstractClientServerIntegrationTest {
                         .withBody("some_body2"),
                 makeRequest(
                         request()
-                                .withBody("{" + System.getProperty("line.separator") +
-                                        "    \"id\": 1," + System.getProperty("line.separator") +
-                                        "    \"name\": \"A green door\"," + System.getProperty("line.separator") +
-                                        "    \"price\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+                                .withBody("{" + NL +
+                                        "    \"id\": 1," + NL +
+                                        "    \"name\": \"A green door\"," + NL +
+                                        "    \"price\": 12.50," + NL +
+                                        "    \"tags\": [\"home\", \"green\"]" + NL +
                                         "}"),
                         headersToIgnore)
         );
@@ -5110,11 +5111,11 @@ public abstract class AbstractClientServerIntegrationTest {
                 makeRequest(
                         request()
                                 .withSecure(true)
-                                .withBody("{" + System.getProperty("line.separator") +
-                                        "    \"id\": 1," + System.getProperty("line.separator") +
-                                        "    \"name\": \"A green door\"," + System.getProperty("line.separator") +
-                                        "    \"price\": 12.50," + System.getProperty("line.separator") +
-                                        "    \"tags\": [\"home\", \"green\"]" + System.getProperty("line.separator") +
+                                .withBody("{" + NL +
+                                        "    \"id\": 1," + NL +
+                                        "    \"name\": \"A green door\"," + NL +
+                                        "    \"price\": 12.50," + NL +
+                                        "    \"tags\": [\"home\", \"green\"]" + NL +
                                         "}"),
                         headersToIgnore)
         );
@@ -5362,6 +5363,6 @@ public abstract class AbstractClientServerIntegrationTest {
                 }
             }
         }
-        throw new RuntimeException("Failed to send request:" + System.getProperty("line.separator") + httpRequest);
+        throw new RuntimeException("Failed to send request:" + NL + httpRequest);
     }
 }

--- a/mockserver-netty/src/test/java/org/mockserver/integration/mockserver/MockServerMultiplePortIntegrationTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/integration/mockserver/MockServerMultiplePortIntegrationTest.java
@@ -81,8 +81,8 @@ public class MockServerMultiplePortIntegrationTest extends AbstractMockServerNet
                 response()
                         .withStatusCode(HttpStatusCode.OK_200.code())
                         .withHeader("Content-Type", "application/json; charset=utf-8")
-                        .withBody("{" + System.getProperty("line.separator") +
-                                "  \"ports\" : [ " + Joiner.on(", ").join(severHttpPort) + " ]" + System.getProperty("line.separator") +
+                        .withBody("{" + NL +
+                                "  \"ports\" : [ " + Joiner.on(", ").join(severHttpPort) + " ]" + NL +
                                 "}"),
                 makeRequest(
                         request()
@@ -95,8 +95,8 @@ public class MockServerMultiplePortIntegrationTest extends AbstractMockServerNet
                 response()
                         .withStatusCode(HttpStatusCode.OK_200.code())
                         .withHeader("Content-Type", "application/json; charset=utf-8")
-                        .withBody("{" + System.getProperty("line.separator") +
-                                "  \"ports\" : [ " + Joiner.on(", ").join(severHttpPort) + " ]" + System.getProperty("line.separator") +
+                        .withBody("{" + NL +
+                                "  \"ports\" : [ " + Joiner.on(", ").join(severHttpPort) + " ]" + NL +
                                 "}"),
                 makeRequest(
                         request()
@@ -119,15 +119,15 @@ public class MockServerMultiplePortIntegrationTest extends AbstractMockServerNet
                 response()
                         .withStatusCode(HttpStatusCode.ACCEPTED_202.code())
                         .withHeader("Content-Type", "application/json; charset=utf-8")
-                        .withBody("{" + System.getProperty("line.separator") +
-                                "  \"ports\" : [ " + firstNewPort + " ]" + System.getProperty("line.separator") +
+                        .withBody("{" + NL +
+                                "  \"ports\" : [ " + firstNewPort + " ]" + NL +
                                 "}"),
                 makeRequest(
                         request()
                                 .withPath(calculatePath("bind"))
                                 .withMethod("PUT")
-                                .withBody("{" + System.getProperty("line.separator") +
-                                        "  \"ports\" : [ " + firstNewPort + " ]" + System.getProperty("line.separator") +
+                                .withBody("{" + NL +
+                                        "  \"ports\" : [ " + firstNewPort + " ]" + NL +
                                         "}"),
                         headersToIgnore)
         );
@@ -135,8 +135,8 @@ public class MockServerMultiplePortIntegrationTest extends AbstractMockServerNet
                 response()
                         .withStatusCode(HttpStatusCode.OK_200.code())
                         .withHeader("Content-Type", "application/json; charset=utf-8")
-                        .withBody("{" + System.getProperty("line.separator") +
-                                "  \"ports\" : [ " + Joiner.on(", ").join(severHttpPort) + ", " + firstNewPort + " ]" + System.getProperty("line.separator") +
+                        .withBody("{" + NL +
+                                "  \"ports\" : [ " + Joiner.on(", ").join(severHttpPort) + ", " + firstNewPort + " ]" + NL +
                                 "}"),
                 makeRequest(
                         request()
@@ -149,16 +149,16 @@ public class MockServerMultiplePortIntegrationTest extends AbstractMockServerNet
                 response()
                         .withStatusCode(HttpStatusCode.ACCEPTED_202.code())
                         .withHeader("Content-Type", "application/json; charset=utf-8")
-                        .withBody("{" + System.getProperty("line.separator") +
-                                "  \"ports\" : [ " + secondNewPort + " ]" + System.getProperty("line.separator") +
+                        .withBody("{" + NL +
+                                "  \"ports\" : [ " + secondNewPort + " ]" + NL +
                                 "}"),
                 makeRequest(
                         request()
                                 .withSecure(true)
                                 .withPath(calculatePath("bind"))
                                 .withMethod("PUT")
-                                .withBody("{" + System.getProperty("line.separator") +
-                                        "  \"ports\" : [ " + secondNewPort + " ]" + System.getProperty("line.separator") +
+                                .withBody("{" + NL +
+                                        "  \"ports\" : [ " + secondNewPort + " ]" + NL +
                                         "}"),
                         headersToIgnore)
         );
@@ -166,16 +166,16 @@ public class MockServerMultiplePortIntegrationTest extends AbstractMockServerNet
                 response()
                         .withStatusCode(HttpStatusCode.OK_200.code())
                         .withHeader("Content-Type", "application/json; charset=utf-8")
-                        .withBody("{" + System.getProperty("line.separator") +
-                                "  \"ports\" : [ " + Joiner.on(", ").join(severHttpPort) + ", " + firstNewPort + ", " + secondNewPort + " ]" + System.getProperty("line.separator") +
+                        .withBody("{" + NL +
+                                "  \"ports\" : [ " + Joiner.on(", ").join(severHttpPort) + ", " + firstNewPort + ", " + secondNewPort + " ]" + NL +
                                 "}"),
                 makeRequest(
                         request()
                                 .withSecure(true)
                                 .withPath(calculatePath("status"))
                                 .withMethod("PUT")
-                                .withBody("{" + System.getProperty("line.separator") +
-                                        "  \"ports\" : [ " + firstNewPort + " ]" + System.getProperty("line.separator") +
+                                .withBody("{" + NL +
+                                        "  \"ports\" : [ " + firstNewPort + " ]" + NL +
                                         "}"),
                         headersToIgnore)
         );
@@ -200,8 +200,8 @@ public class MockServerMultiplePortIntegrationTest extends AbstractMockServerNet
                             request()
                                     .withPath(calculatePath("bind"))
                                     .withMethod("PUT")
-                                    .withBody("{" + System.getProperty("line.separator") +
-                                            "  \"ports\" : [ " + newPort + " ]" + System.getProperty("line.separator") +
+                                    .withBody("{" + NL +
+                                            "  \"ports\" : [ " + newPort + " ]" + NL +
                                             "}"),
                             headersToIgnore)
             );

--- a/mockserver-war/src/test/java/org/mockserver/server/DeployableWARAbstractClientServerIntegrationTest.java
+++ b/mockserver-war/src/test/java/org/mockserver/server/DeployableWARAbstractClientServerIntegrationTest.java
@@ -1,33 +1,15 @@
 package org.mockserver.server;
 
-import com.google.common.base.Charsets;
 import com.google.common.net.HttpHeaders;
-import com.google.common.net.MediaType;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockserver.client.server.ClientException;
-import org.mockserver.integration.server.AbstractClientServerIntegrationTest;
 import org.mockserver.integration.server.SameJVMAbstractClientServerIntegrationTest;
 import org.mockserver.model.HttpStatusCode;
-import org.mockserver.socket.SSLFactory;
-import org.mockserver.streams.IOStreamUtils;
-
-import javax.net.ssl.SSLSocket;
-import java.io.OutputStream;
-import java.net.Socket;
-import java.net.SocketException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.core.AnyOf.anyOf;
-import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-import static org.mockserver.model.BinaryBody.binary;
 import static org.mockserver.model.ConnectionOptions.connectionOptions;
 import static org.mockserver.model.Header.header;
 import static org.mockserver.model.HttpCallback.callback;
@@ -159,8 +141,8 @@ public abstract class DeployableWARAbstractClientServerIntegrationTest extends S
                 response()
                         .withStatusCode(HttpStatusCode.OK_200.code())
                         .withHeader("Content-Type", "application/json; charset=utf-8")
-                        .withBody("{" + System.getProperty("line.separator") +
-                                "  \"ports\" : [ " + getMockServerPort() + " ]" + System.getProperty("line.separator") +
+                        .withBody("{" + NL +
+                                "  \"ports\" : [ " + getMockServerPort() + " ]" + NL +
                                 "}"),
                 makeRequest(
                         request()
@@ -173,8 +155,8 @@ public abstract class DeployableWARAbstractClientServerIntegrationTest extends S
                 response()
                         .withStatusCode(HttpStatusCode.OK_200.code())
                         .withHeader("Content-Type", "application/json; charset=utf-8")
-                        .withBody("{" + System.getProperty("line.separator") +
-                                "  \"ports\" : [ " + getMockServerSecurePort() + " ]" + System.getProperty("line.separator") +
+                        .withBody("{" + NL +
+                                "  \"ports\" : [ " + getMockServerSecurePort() + " ]" + NL +
                                 "}"),
                 makeRequest(
                         request()

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jetty.version>8.1.16.v20140903</jetty.version>
         <slf4j.version>1.7.12</slf4j.version>
         <!-- tomcat version &gt; 7.0.56 causes SSL to fail -->

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <properties>
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
-        <project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jetty.version>8.1.16.v20140903</jetty.version>
         <slf4j.version>1.7.12</slf4j.version>
         <!-- tomcat version &gt; 7.0.56 causes SSL to fail -->

--- a/pom.xml
+++ b/pom.xml
@@ -289,13 +289,6 @@
                 <version>2.2.6</version>
             </dependency>
 
-            <!-- xml -->
-            <dependency>
-                <groupId>xerces</groupId>
-                <artifactId>xerces</artifactId>
-                <version>2.4.0</version>
-            </dependency>
-
             <!-- commons & guava -->
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Hi,

first of all, thank you for this great library, which I use to write HTTP client tests.

During development, I've discovered some issues with Xerces being in classpath *1)
and registering it's parsers. Modern JRE XML implementations are way more up-to-date.
Thus I removed the Xerces dependency and just using standard JRE features for pretty printing an XML.
As a result, the tests needed to be adopted, because now they are correctly pretty printed, including NewLine character.

*1)
See e.g. https://github.com/freedomotic/freedomotic/pull/183

Any feedback is welcome.

Regards
Martin