### PR TITLE
Update json dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jdk:
   - oraclejdk7
 
 rvm:
-  - "2.0.0"
+  - "2.2.3"
 
 # whitelist
 branches:

--- a/mockserver-client-ruby/lib/mockserver-client.rb
+++ b/mockserver-client-ruby/lib/mockserver-client.rb
@@ -2,16 +2,3 @@
 require_relative './mockserver/version'
 require_relative './mockserver/mock_server_client'
 require_relative './mockserver/proxy_client'
-
-# Setup serialization correctly with multi_json
-require 'json/pure'
-
-# To fix serialization bugs. See: http://prettystatemachine.blogspot.com/2010/09/typeerrors-in-tojson-make-me-briefly.html
-class Fixnum
-  def to_json(_)
-    to_s
-  end
-end
-
-require 'multi_json'
-MultiJson.use(:json_pure)

--- a/mockserver-client-ruby/lib/mockserver/model/enum.rb
+++ b/mockserver-client-ruby/lib/mockserver/model/enum.rb
@@ -33,6 +33,14 @@ module MockServer::Model
     def to_s
       @value.to_s
     end
+
+    def as_json(_)
+      @value.to_s
+    end
+
+    def to_json(_)
+      "\"#{@value}\""
+    end
   end
 
   # Subclass of Enum that has a list of symbols as allowed values.

--- a/mockserver-client-ruby/mockserver-client.gemspec
+++ b/mockserver-client-ruby/mockserver-client.gemspec
@@ -28,10 +28,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.23'
 
   spec.add_dependency 'hashie', '~> 3.0'
-  spec.add_dependency 'json', '~> 1.8'
-  spec.add_dependency 'json_pure', '~> 1.8'
-  spec.add_dependency 'activesupport', '~> 4.1'
-  spec.add_dependency 'rest-client', '~> 1.7'
+  spec.add_dependency 'json', '>= 1.8'
+  spec.add_dependency 'activesupport', '>= 4.1'
+  spec.add_dependency 'rest-client', '>= 1.7'
   spec.add_dependency 'logging_factory', '~> 0.0.2'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'colorize', '~> 0.7'


### PR DESCRIPTION
In order to get the ruby client working with my Rails 5 based project, I had to remove the json dependency constraints as well as activesupport and rest_client constraints since I was locked to newer versions of these.

In theory this client should be designed to work with whatever json package is used by the project that it gets included in, rather than bringing in it's own json dependency.
- [x] _specs pass with this change_ except for one spec that seems to depend on launching an actual server to test against. 
- [x] _client works with my Rails 5 project_
- [ ] maybe would be a good idea to update specs to test against different json gems?

NB: the specs call the `to_json` method in `Enum`. My project calls the `as_json` method in `Enum` so the `as_json` case is not currently covered in the specs.

Let me know if this seems like a good direction. I couldn't tell if this was the final version of the ruby client or if there's still a new version in the works. Cheers!
