### PR TITLE
Allow RFC2965-style attributes in Cookie header 

### DIFF
--- a/mockserver-netty/src/main/java/org/mockserver/codec/MockServerRequestDecoder.java
+++ b/mockserver-netty/src/main/java/org/mockserver/codec/MockServerRequestDecoder.java
@@ -1,13 +1,11 @@
 package org.mockserver.codec;
 
-import com.google.common.base.Splitter;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageDecoder;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.QueryStringDecoder;
 import io.netty.handler.codec.http.cookie.*;
-import org.apache.commons.lang3.StringUtils;
 import org.mockserver.mappers.ContentTypeMapper;
 import org.mockserver.model.*;
 import org.mockserver.model.Cookie;
@@ -17,6 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.charset.Charset;
 import java.util.List;
+import java.util.Set;
 
 import static io.netty.handler.codec.http.HttpHeaders.Names.COOKIE;
 import static io.netty.handler.codec.http.HttpHeaders.isKeepAlive;
@@ -91,19 +90,19 @@ public class MockServerRequestDecoder extends MessageToMessageDecoder<FullHttpRe
             httpRequest.withHeader(new Header(headerName, headers.getAll(headerName)));
         }
     }
-
+    
     private void setCookies(HttpRequest httpRequest, FullHttpRequest fullHttpResponse) {
         for (String cookieHeader : fullHttpResponse.headers().getAll(COOKIE)) {
-            for (String cookie : Splitter.on(";").split(cookieHeader)) {
-                if (!cookie.trim().isEmpty()) {
-                    io.netty.handler.codec.http.cookie.Cookie decodedCookie =
-                            ClientCookieDecoder.LAX.decode(cookie);
-                    httpRequest.withCookie(new Cookie(
-                            decodedCookie.name(),
-                            decodedCookie.value()
-                    ));
-                }
+            Set<io.netty.handler.codec.http.cookie.Cookie> decodedCookies =
+                    ServerCookieDecoder.LAX.decode(cookieHeader);
+            for (io.netty.handler.codec.http.cookie.Cookie decodedCookie: decodedCookies) {
+                httpRequest.withCookie(new Cookie(
+                        decodedCookie.name(),
+                        decodedCookie.value()
+                ));
             }
+   
         }
     }
+
 }

--- a/mockserver-netty/src/main/java/org/mockserver/codec/MockServerRequestDecoder.java
+++ b/mockserver-netty/src/main/java/org/mockserver/codec/MockServerRequestDecoder.java
@@ -101,8 +101,6 @@ public class MockServerRequestDecoder extends MessageToMessageDecoder<FullHttpRe
                         decodedCookie.value()
                 ));
             }
-   
         }
     }
-
 }

--- a/mockserver-netty/src/test/java/org/mockserver/codec/MockServerRequestDecoderTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/codec/MockServerRequestDecoderTest.java
@@ -1,4 +1,5 @@
 package org.mockserver.codec;
+
 import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import io.netty.buffer.Unpooled;
@@ -23,7 +24,6 @@ import static org.mockserver.model.Header.header;
 import static org.mockserver.model.NottableString.string;
 import static org.mockserver.model.Parameter.param;
 import static org.mockserver.model.StringBody.exact;
-
 
 /**
  * @author jamesdbloom


### PR DESCRIPTION
This patch allows the Mock Server to gracefully handle HTTP requests that include the extra attributes that are defined in IETF's RFC2965 https://tools.ietf.org/html/rfc2965. All existing functionality is preserved, and the code now relies on Netty's implementation for the parsing of the Cookie header instead of splitting the string explicitly. 

I would like for this to be reviewed, and hopefully merged and released so that I can revert to using a production version of the library in my project instead of patching the library to be compatible with existing code).


These RFC2965 attributes start with a dollar sign "$". Here's an example Cookie header:
`Cookie = $Version=1; cookieName=CookieValue ; $Path=/resource`

Before this patch, MockServer would throw an exception while trying to parse this header. The root cause is that it is using Netty's ClientCookieDecoder instead of the ServerCookieDecoder (and these attributes beginning with a dollar-sign are passed from client to server, rather than from server to client)

This is important to me because I'm using the Jersey library on a project with a REST service that uses a cookie, and Jersey follows this style of adding the $Version to all cookies. 

To show the issue - this simple JUnit test with some example Jersey client code will fail without the patch, and will now pass after the patch. 

```java
package org.mockserver.codec;

import static org.mockserver.integration.ClientAndServer.startClientAndServer;
import static org.mockserver.model.Cookie.cookie;
import static org.mockserver.model.HttpRequest.request;
import static org.mockserver.model.HttpResponse.response;

import javax.ws.rs.client.Client;
import javax.ws.rs.client.ClientBuilder;
import javax.ws.rs.client.WebTarget;
import javax.ws.rs.core.Response;

import org.junit.Test;
import org.mockserver.integration.ClientAndServer;
import org.mockserver.socket.PortFactory;
/*
 * 
 * Demonstrate the feature required and why it's important...
 * 
 <dependency>
    <groupId>org.glassfish.jersey.core</groupId>
    <artifactId>jersey-client</artifactId>
    <version>2.12</version>
</dependency>
 */
public class JerseyTest {


    @Test 
    public void shouldWorkWithJersey() { 
    	int SERVER_HTTP_PORT = PortFactory.findFreePort();
    	ClientAndServer mockServerClient = startClientAndServer(SERVER_HTTP_PORT);

		// given
		mockServerClient.when(request("/resource").withMethod("GET"))
		.respond(response().withBody("Hiya!"));;
    	
    	
    	Client client = ClientBuilder.newClient();
    	WebTarget target = client.target("http://localhost:"+ SERVER_HTTP_PORT).path("resource");
    	 
    	target.request().cookie("k","v").get();
    	
    	mockServerClient.verify(request().withCookie(cookie("k", "v")));
    	
    	// stop mock server and client
        if (mockServerClient instanceof ClientAndServer) {
            mockServerClient.stop();
        }
    }

}

```
