### PR TITLE
bump rubygem version

### DIFF
--- a/mockserver-client-ruby/lib/mockserver/version.rb
+++ b/mockserver-client-ruby/lib/mockserver/version.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
 # Version for this gem
 module MockServer
-  VERSION = '1.0.8.pre'
+  VERSION = '1.0.9'
 end


### PR DESCRIPTION
@jamesdbloom it's about time to release `1.0.9` and build gem, so we can get mockserver client working again with later versions of rails!