### PR TITLE
Changing the queue in the request log to be thread safe #300

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/filters/RequestLogFilter.java
+++ b/mockserver-core/src/main/java/org/mockserver/filters/RequestLogFilter.java
@@ -1,6 +1,7 @@
 package org.mockserver.filters;
 
 import com.google.common.collect.EvictingQueue;
+import com.google.common.collect.Queues;
 import org.mockserver.client.serialization.HttpRequestSerializer;
 import org.mockserver.logging.LogFormatter;
 import org.mockserver.matchers.HttpRequestMatcher;
@@ -13,9 +14,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
 
 /**
  * @author jamesdbloom
@@ -24,7 +25,8 @@ public class RequestLogFilter implements ResponseFilter, RequestFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(RequestLogFilter.class);
     // request persistence
-    private final EvictingQueue<HttpRequest> requestLog = EvictingQueue.create(100);
+    private final EvictingQueue<HttpRequest> evictingQueue = EvictingQueue.create(100);
+    private final Queue<HttpRequest> requestLog =  Queues.synchronizedQueue(evictingQueue);
 
     // matcher
     private final MatcherBuilder matcherBuilder = new MatcherBuilder();

--- a/mockserver-core/src/test/java/org/mockserver/filters/RequestLogFilterTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/filters/RequestLogFilterTest.java
@@ -9,10 +9,7 @@ import org.mockserver.model.HttpResponse;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -42,10 +39,15 @@ public class RequestLogFilterTest {
 
         ExecutorService executorService = Executors.newFixedThreadPool(100);
 
-        List<Future<HttpRequest>> httpRequestFutureList = new ArrayList<>();
+        List<Future<HttpRequest>> httpRequestFutureList = new ArrayList<Future<HttpRequest>>();
 
         for (int i = 0; i < 10000; i++) {
-            Future<HttpRequest> futureHttpRequest = executorService.submit(() -> requestLogFilter.onRequest(httpRequest));
+            Future<HttpRequest> futureHttpRequest = executorService.submit(new Callable<HttpRequest>() {
+                @Override
+                public HttpRequest call() throws Exception {
+                    return requestLogFilter.onRequest(httpRequest);
+                }
+            });
             httpRequestFutureList.add(futureHttpRequest);
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
 
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
         <project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
         <jetty.version>8.1.16.v20140903</jetty.version>
         <slf4j.version>1.7.12</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
 
 
     <properties>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
         <jetty.version>8.1.16.v20140903</jetty.version>
         <slf4j.version>1.7.12</slf4j.version>


### PR DESCRIPTION
Hi

Under a load of the mockserver/proxy i was getting 

java.util.NoSuchElementException: null
	at java.util.ArrayDeque.removeFirst(ArrayDeque.java:280)
	at java.util.ArrayDeque.remove(ArrayDeque.java:447)
	at com.google.common.collect.EvictingQueue.add(EvictingQueue.java:105)
	at org.mockserver.filters.RequestLogFilter.onRequest(RequestLogFilter.java:41)
	at org.mockserver.filters.Filters.applyOnRequestFilters(Filters.java:33)
	at org.mockserver.mock.action.ActionHandler.processAction(ActionHandler.java:27)
	at org.mockserver.mockserver.MockServerHandler.channelRead0(MockServerHandler.java:179)
	at org.mockserver.mockserver.MockServerHandler.channelRead0(MockServerHandler.java:41)
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:105)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:307)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:293)
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHand
...


Similar to what was described in issue #300 
Although i saw the comment to the /* synchronized */  keyword
I wrapped the EvictingQueue with synchronized queue to make it thread safe. 


Test is written with java 8 future and diamond features
So if it's possible to update the java version it will be great
if not i can downgrade the test to java 6