### PR TITLE
Fixes default charset for utf file types for example application/json to UTF-8

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/mappers/ContentTypeMapper.java
+++ b/mockserver-core/src/main/java/org/mockserver/mappers/ContentTypeMapper.java
@@ -101,6 +101,8 @@ public class ContentTypeMapper {
                 } catch (IllegalCharsetNameException icne) {
                     logger.info("Illegal character set {} in Content-Type header: {}.", StringUtils.substringAfterLast(contentType, HttpHeaders.Values.CHARSET + HttpConstants.EQUALS), contentType);
                 }
+            } else if (ContentTypeUtil.utf8ContentTypes.containsKey(contentType)) {
+                charset = CharsetUtil.UTF_8;
             }
         }
         return charset;

--- a/mockserver-core/src/main/java/org/mockserver/mappers/ContentTypeUtil.java
+++ b/mockserver-core/src/main/java/org/mockserver/mappers/ContentTypeUtil.java
@@ -1,0 +1,36 @@
+package org.mockserver.mappers;
+
+import com.google.common.collect.ImmutableMap;
+import io.netty.util.CharsetUtil;
+
+import java.nio.charset.Charset;
+import java.util.Map;
+
+public class ContentTypeUtil {
+    static Map<String, Integer> utf8ContentTypes = ImmutableMap.<String, Integer>builder().
+            put("application/atom+xml", 1).
+            put("application/ecmascript", 1).
+            put("application/javascript", 1).
+            put("application/json", 1).
+            put("application/jsonml+json", 1).
+            put("application/lost+xml", 1).
+            put("application/wsdl+xml", 1).
+            put("application/xaml+xml", 1).
+            put("application/xhtml+xml", 1).
+            put("application/xml", 1).
+            put("application/xml-dtd", 1).
+            put("application/xop+xml", 1).
+            put("application/xslt+xml", 1).
+            put("application/xspf+xml", 1).
+            put("application/x-www-form-urlencoded", 1).
+            put("image/svg+xml", 1).
+            put("text/css", 1).
+            put("text/csv", 1).
+            put("text/html", 1).
+            put("text/plain", 1).
+            put("text/richtext", 1).
+            put("text/sgml", 1).
+            put("text/tab-separated-values", 1).
+            put("text/x-fortran", 1).
+            put("text/x-java-source", 1).build();
+}

--- a/mockserver-core/src/test/java/org/mockserver/mappers/ContentTypeMapperTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/mappers/ContentTypeMapperTest.java
@@ -4,6 +4,7 @@ import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMessage;
+import io.netty.util.CharsetUtil;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
@@ -240,6 +241,18 @@ public class ContentTypeMapperTest {
 
         // then
         assertThat(charset, is(ContentTypeMapper.DEFAULT_HTTP_CHARACTER_SET));
+    }
+
+    @Test
+    public void shouldDetermineUTFCharsetFromResponseContentTypeForHttpResponseWhenUTFDefaultCharset() {
+        // when
+        Charset charset = ContentTypeMapper.determineCharsetForMessage(
+                response()
+                        .withHeader(HttpHeaders.Names.CONTENT_TYPE, "application/json")
+        );
+
+        // then
+        assertThat(charset, is(CharsetUtil.UTF_8));
     }
 
     @Test


### PR DESCRIPTION
This pull request aims at solving the issue for default charset of application/json being ISO-8859-1 instead of UTF as described in this issue.
[https://github.com/jamesdbloom/mockserver/issues/162](url) 

The default charset here for UTF file type is set to UTF-8 unless specified otherwise in the charset parameter.