### PR TITLE
Support CORS with credentials

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/configuration/ConfigurationProperties.java
+++ b/mockserver-core/src/main/java/org/mockserver/configuration/ConfigurationProperties.java
@@ -61,6 +61,15 @@ public class ConfigurationProperties {
         System.setProperty("mockserver.enableCORSForAllResponses", "" + enableCORSForAPI);
     }
 
+    // credentials config for CORS
+    public static boolean enableCredentialsForCORS() {
+        return Boolean.parseBoolean(readPropertyHierarchically("mockserver.enableCredentialsForCORS", "" + false));
+    }
+
+    public static void enableCredentialsForCORS(boolean enableCredentialsForCORS) {
+        System.setProperty("mockserver.enableCredentialsForCORS", "" + enableCredentialsForCORS);
+    }
+
     // socket config
     public static long maxSocketTimeout() {
         return readLongProperty("mockserver.maxSocketTimeout", TimeUnit.SECONDS.toMillis(DEFAULT_MAX_TIMEOUT));

--- a/mockserver-core/src/test/java/org/mockserver/configuration/ConfigurationPropertiesTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/configuration/ConfigurationPropertiesTest.java
@@ -71,6 +71,20 @@ public class ConfigurationPropertiesTest {
         assertEquals(false, ConfigurationProperties.enableCORSForAllResponses());
         assertEquals("false", System.getProperty("mockserver.enableCORSForAllResponses"));
     }
+
+    @Test
+    public void shouldSetAndReadEnableCredentialsForCORS() {
+        // given
+        System.clearProperty("mockserver.enableCredentialsForCORS");
+
+        // when
+        assertEquals(false, ConfigurationProperties.enableCredentialsForCORS());
+        ConfigurationProperties.enableCredentialsForCORS(true);
+
+        // then
+        assertEquals(true, ConfigurationProperties.enableCredentialsForCORS());
+        assertEquals("true", System.getProperty("mockserver.enableCredentialsForCORS"));
+    }
     
     @Test
     public void shouldSetAndReadMaxSocketTimeout() {

--- a/mockserver-war/src/test/java/org/mockserver/server/MockServerServletCORSTest.java
+++ b/mockserver-war/src/test/java/org/mockserver/server/MockServerServletCORSTest.java
@@ -84,6 +84,36 @@ public class MockServerServletCORSTest {
     }
 
     @Test
+    public void shouldSetAllowedOriginToSourceOriginForOptionsRequestAllowingCredentials() {
+        boolean originalEnableCredentialsForCORS = ConfigurationProperties.enableCredentialsForCORS();
+        try {
+        // given
+        MockHttpServletResponse httpServletResponse = new MockHttpServletResponse();
+        HttpRequest request = request().withMethod("OPTIONS").withHeader("Origin", "some_origin");
+        when(mockHttpServletRequestToMockServerRequestDecoder.mapHttpServletRequestToMockServerRequest(any(HttpServletRequest.class))).thenReturn(request);
+
+        // but - credentials for CORS enabled
+        ConfigurationProperties.enableCredentialsForCORS(true);
+
+        // when
+        mockServerServlet.service(new MockHttpServletRequest(), httpServletResponse);
+
+        // then
+        assertThat(httpServletResponse.getStatus(), is(200));
+        assertThat(httpServletResponse.getHeader("Access-Control-Allow-Origin"), is("some_origin"));
+        assertThat(httpServletResponse.getHeader("Access-Control-Allow-Credentials"), is("true"));
+        assertThat(httpServletResponse.getHeader("Access-Control-Allow-Methods"), is("CONNECT, DELETE, GET, HEAD, OPTIONS, POST, PUT, TRACE"));
+        assertThat(httpServletResponse.getHeader("Access-Control-Allow-Headers"), is("Allow, Content-Encoding, Content-Length, Content-Type, ETag, Expires, Last-Modified, Location, Server, Vary"));
+        assertThat(httpServletResponse.getHeader("Access-Control-Expose-Headers"), is("Allow, Content-Encoding, Content-Length, Content-Type, ETag, Expires, Last-Modified, Location, Server, Vary"));
+        assertThat(httpServletResponse.getHeader("Access-Control-Max-Age"), is("1"));
+        assertThat(httpServletResponse.getHeader("X-CORS"), is("MockServer CORS support enabled by default, to disable ConfigurationProperties.enableCORSForAPI(false) or -Dmockserver.disableCORS=false"));
+
+        } finally {
+            ConfigurationProperties.enableCredentialsForCORS(originalEnableCredentialsForCORS);
+        }
+    }
+
+    @Test
     public void shouldNotAddCORSHeadersForOptionsRequestWithoutOrigin() {
         // given
         MockHttpServletResponse httpServletResponse = new MockHttpServletResponse();

--- a/mockserver.example.properties
+++ b/mockserver.example.properties
@@ -34,3 +34,5 @@ mockserver.sslSubjectAlternativeNameIps=127.0.0.1
 mockserver.enableCORSForAPI=true
 # enable CORS for all responses
 mockserver.enableCORSForAllResponses=true
+# enable CORS to set Access-Control-Allow-Credentials to true
+mockserver.enableCredentialsForCORS=true


### PR DESCRIPTION
Currently mockserver will respond with the CORS header `Access-Control-Allow-Origin: "*"` on all CORS requests. Unfortunately `*` is not allowed by the browser if credentials are going to be sent on the request. [MDN explaination](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Requests_with_credentials).

I've had a go at adding support for this use case into mockserver. I thought the safest thing would be to add this functionality under a new config flag. 

Is this something you would consider merging in? Anything you will need to see changed first? 


