### PR TITLE
MockServerClient and EchoServer being Closeable

### DIFF
--- a/mockserver-client-java/pom.xml
+++ b/mockserver-client-java/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>3.10.9-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-client-java/src/main/java/org/mockserver/client/server/MockServerClient.java
+++ b/mockserver-client-java/src/main/java/org/mockserver/client/server/MockServerClient.java
@@ -1,6 +1,8 @@
 package org.mockserver.client.server;
 
 import com.google.common.base.Charsets;
+import java.io.Closeable;
+import java.io.IOException;
 import org.mockserver.client.AbstractClient;
 import org.mockserver.client.netty.SocketConnectionException;
 import org.mockserver.matchers.TimeToLive;
@@ -22,7 +24,7 @@ import static org.mockserver.verify.Verification.verification;
 /**
  * @author jamesdbloom
  */
-public class MockServerClient extends AbstractClient {
+public class MockServerClient extends AbstractClient implements Closeable {
 
     /**
      * Start the client communicating to a MockServer at the specified host and port
@@ -200,6 +202,11 @@ public class MockServerClient extends AbstractClient {
             }
         }
         return this;
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.stop(true);
     }
 
     /**

--- a/mockserver-client-java/src/test/java/org/mockserver/client/server/MockServerClientIntegrationTest.java
+++ b/mockserver-client-java/src/test/java/org/mockserver/client/server/MockServerClientIntegrationTest.java
@@ -1,5 +1,6 @@
 package org.mockserver.client.server;
 
+import java.io.IOException;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
 import org.mockserver.client.serialization.ExpectationSerializer;
@@ -412,6 +413,25 @@ public class MockServerClientIntegrationTest {
         if (result != null && !result.isEmpty()) {
             throw new AssertionError(result);
         }
+    }
+
+    @Test
+    public void shouldSendStopRequestAsResource() throws IOException {
+      // given
+      int specificFreePort = PortFactory.findFreePort();
+      try (EchoServer specificEchoServer = new EchoServer(specificFreePort, false)) {
+
+        // when
+        try (MockServerClient ignore = new MockServerClient("localhost", specificFreePort)) {
+        }
+
+        // then
+        String result = specificEchoServer.requestLogFilter().verify(verificationSequence().withRequests(
+            request().withMethod("PUT").withPath("/stop")
+        ));
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.isEmpty());
+      }
     }
 
     @Test

--- a/mockserver-client-java/src/test/java/org/mockserver/client/server/MockServerClientTest.java
+++ b/mockserver-client-java/src/test/java/org/mockserver/client/server/MockServerClientTest.java
@@ -445,6 +445,15 @@ public class MockServerClientTest {
     }
 
     @Test
+    public void closeShouldSendStopRequest() throws Exception {
+        // when
+        mockServerClient.close();
+
+        // then
+        verify(mockHttpClient).sendRequest(request().withHeader(HOST.toString(), "localhost:" + 1080).withMethod("PUT").withPath("/stop"));
+    }
+
+    @Test
     public void shouldQueryRunningStatus() throws Exception {
         // given
         when(mockHttpClient.sendRequest(any(HttpRequest.class))).thenReturn(response().withStatusCode(HttpStatusCode.OK_200.code()));

--- a/mockserver-core/pom.xml
+++ b/mockserver-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>3.10.9-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-core/src/main/java/org/mockserver/echo/http/EchoServer.java
+++ b/mockserver-core/src/main/java/org/mockserver/echo/http/EchoServer.java
@@ -10,6 +10,8 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.util.AttributeKey;
+import java.io.Closeable;
+import java.io.IOException;
 import org.mockserver.filters.RequestLogFilter;
 import org.mockserver.model.HttpResponse;
 import org.slf4j.Logger;
@@ -20,8 +22,7 @@ import java.util.LinkedList;
 import java.util.Queue;
 import java.util.concurrent.TimeUnit;
 
-
-public class EchoServer {
+public class EchoServer implements Closeable {
 
     static final AttributeKey<RequestLogFilter> LOG_FILTER = AttributeKey.valueOf("SERVER_LOG_FILTER");
     static final AttributeKey<NextResponse> NEXT_RESPONSE = AttributeKey.valueOf("NEXT_RESPONSE");
@@ -77,6 +78,11 @@ public class EchoServer {
 
     public void stop() {
         eventLoopGroup.shutdownGracefully(0, 1, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.stop();
     }
 
     public RequestLogFilter requestLogFilter() {

--- a/mockserver-examples/pom.xml
+++ b/mockserver-examples/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>3.10.9-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-integration-testing/pom.xml
+++ b/mockserver-integration-testing/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>3.10.9-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-integration-testing/src/main/java/org/mockserver/integration/server/AbstractClientServerIntegrationTest.java
+++ b/mockserver-integration-testing/src/main/java/org/mockserver/integration/server/AbstractClientServerIntegrationTest.java
@@ -163,10 +163,9 @@ public abstract class AbstractClientServerIntegrationTest {
     }
 
     @Test
-    public void shouldForwardRequestInHTTPS() {
+    public void shouldForwardRequestInHTTPS() throws IOException {
         int testServerHttpsPort = PortFactory.findFreePort();
-        EchoServer secureEchoServer = new EchoServer(testServerHttpsPort, true);
-        try {
+        try (EchoServer ignored = new EchoServer(testServerHttpsPort, true)) {
             // when
             mockServerClient
                     .when(
@@ -218,8 +217,6 @@ public abstract class AbstractClientServerIntegrationTest {
                                     .withBody("an_example_body_https"),
                             headersToIgnore)
             );
-        } finally {
-            secureEchoServer.stop();
         }
     }
 

--- a/mockserver-logging/pom.xml
+++ b/mockserver-logging/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>3.10.9-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-maven-plugin-integration-tests/pom.xml
+++ b/mockserver-maven-plugin-integration-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>3.10.9-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-maven-plugin/pom.xml
+++ b/mockserver-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>3.10.9-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-netty/pom.xml
+++ b/mockserver-netty/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>3.10.9-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-proxy-war/pom.xml
+++ b/mockserver-proxy-war/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>3.10.9-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-war/pom.xml
+++ b/mockserver-war/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>3.10.9-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.mock-server</groupId>
     <artifactId>mockserver</artifactId>
-    <version>3.10.9-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>MockServer</name>
@@ -42,8 +42,8 @@
 
 
     <properties>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
         <project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
         <jetty.version>8.1.16.v20140903</jetty.version>
         <slf4j.version>1.7.25</slf4j.version>


### PR DESCRIPTION
MockServerClient (and EchoServer) should be a [Closeable](https://docs.oracle.com/javase/7/docs/api/java/io/Closeable.html), so it can be used as a resource in the [try-with-resource statement](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html). This improves cleanup of mockserver.