### PR TITLE
clear requests for dumpTo* function then /clear was called

### DIFF
--- a/mockserver-netty/src/main/java/org/mockserver/proxy/http/HttpProxyHandler.java
+++ b/mockserver-netty/src/main/java/org/mockserver/proxy/http/HttpProxyHandler.java
@@ -104,6 +104,7 @@ public class HttpProxyHandler extends SimpleChannelInboundHandler<HttpRequest> {
             } else if (request.matches("PUT", "/clear")) {
 
                 org.mockserver.model.HttpRequest httpRequest = httpRequestSerializer.deserialize(request.getBodyAsString());
+                requestResponseLogFilter.clear(httpRequest);
                 requestLogFilter.clear(httpRequest);
                 logFormatter.infoLog("clearing expectations and request logs that match:{}", httpRequest);
                 writeResponse(ctx, request, OK);


### PR DESCRIPTION
Use case:

//make request1
proxyClient.dumpToLogAsJava();
proxyClient.clear(HttpRequest.request())
//make request2
proxyClient.dumpToLogAsJava();

Expectation:
in first call dumpToLogAsJava  I get request1. In second request2

Actual:
in first call dumpToLogAsJava I get request1. In second request1 and request2