### PR TITLE
Remove obsolete Xerces dependency

### DIFF
--- a/mockserver-core/pom.xml
+++ b/mockserver-core/pom.xml
@@ -91,12 +91,6 @@
             <artifactId>json-schema-validator</artifactId>
         </dependency>
 
-        <!-- xml -->
-        <dependency>
-            <groupId>xerces</groupId>
-            <artifactId>xerces</artifactId>
-        </dependency>
-
         <!-- commons & guava -->
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/mockserver-core/src/main/java/org/mockserver/matchers/StringToXmlDocumentParser.java
+++ b/mockserver-core/src/main/java/org/mockserver/matchers/StringToXmlDocumentParser.java
@@ -1,11 +1,12 @@
 package org.mockserver.matchers;
 
-import com.google.common.base.Charsets;
-import org.apache.xml.serialize.Method;
-import org.apache.xml.serialize.OutputFormat;
-import org.apache.xml.serialize.XMLSerializer;
 import org.mockserver.model.ObjectWithReflectiveEqualsHashCodeToString;
+import org.w3c.dom.DOMConfiguration;
+import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
+import org.w3c.dom.ls.DOMImplementationLS;
+import org.w3c.dom.ls.LSOutput;
+import org.w3c.dom.ls.LSSerializer;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -14,23 +15,43 @@ import org.xml.sax.SAXParseException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import java.io.ByteArrayOutputStream;
+import javax.xml.transform.TransformerException;
 import java.io.IOException;
 import java.io.StringReader;
+import java.io.StringWriter;
 
 /**
  * @author jamesdbloom
  */
 public class StringToXmlDocumentParser extends ObjectWithReflectiveEqualsHashCodeToString {
 
-    public String normaliseXmlString(String matched, ErrorLogger errorLogger) throws IOException, SAXException, ParserConfigurationException {
+    public String normaliseXmlString(String matched, ErrorLogger errorLogger)
+            throws IOException, SAXException, ParserConfigurationException, TransformerException {
         return prettyPrintXmlDocument(buildDocument(matched, errorLogger));
     }
 
-    private String prettyPrintXmlDocument(Document doc) throws IOException {
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        new XMLSerializer(byteArrayOutputStream, new OutputFormat(Method.XML, Charsets.UTF_8.name(), true)).serialize(doc);
-        return byteArrayOutputStream.toString(Charsets.UTF_8.name());
+    static String prettyPrintXmlDocument(Document document) {
+        // Pretty-prints a DOM document to XML using DOM Load and Save's LSSerializer.
+        // Note that the "format-pretty-print" DOM configuration parameter can only be set in JDK 1.6+.
+        DOMImplementation domImplementation = document.getImplementation();
+        if (domImplementation.hasFeature("LS", "3.0") && domImplementation.hasFeature("Core", "2.0")) {
+            DOMImplementationLS domImplementationLS = (DOMImplementationLS) domImplementation.getFeature("LS", "3.0");
+            LSSerializer lsSerializer = domImplementationLS.createLSSerializer();
+            DOMConfiguration domConfiguration = lsSerializer.getDomConfig();
+            if (domConfiguration.canSetParameter("format-pretty-print", Boolean.TRUE)) {
+                lsSerializer.getDomConfig().setParameter("format-pretty-print", Boolean.TRUE);
+                LSOutput lsOutput = domImplementationLS.createLSOutput();
+                lsOutput.setEncoding("UTF-8");
+                StringWriter stringWriter = new StringWriter();
+                lsOutput.setCharacterStream(stringWriter);
+                lsSerializer.write(document, lsOutput);
+                return stringWriter.toString();
+            } else {
+                throw new RuntimeException("DOMConfiguration 'format-pretty-print' parameter isn't settable.");
+            }
+        } else {
+            throw new RuntimeException("DOM 3.0 LS and/or DOM 2.0 Core not supported.");
+        }
     }
 
     public Document buildDocument(final String matched, final ErrorLogger errorLogger) throws ParserConfigurationException, IOException, SAXException {

--- a/mockserver-core/src/main/java/org/mockserver/matchers/XmlStringMatcher.java
+++ b/mockserver-core/src/main/java/org/mockserver/matchers/XmlStringMatcher.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
 import java.io.IOException;
 
 import static org.mockserver.model.NottableString.string;
@@ -34,7 +35,7 @@ public class XmlStringMatcher extends BodyMatcher<NottableString> {
         }
     }
 
-    public String normaliseXmlString(final String input) throws ParserConfigurationException, SAXException, IOException {
+    public String normaliseXmlString(final String input) throws ParserConfigurationException, SAXException, IOException, TransformerException {
         return stringToXmlDocumentParser.normaliseXmlString(input, new StringToXmlDocumentParser.ErrorLogger() {
             @Override
             public void logError(final String matched, final Exception exception) {
@@ -43,7 +44,8 @@ public class XmlStringMatcher extends BodyMatcher<NottableString> {
         });
     }
 
-    public NottableString normaliseXmlNottableString(final NottableString input) throws IOException, SAXException, ParserConfigurationException {
+    public NottableString normaliseXmlNottableString(final NottableString input)
+            throws IOException, SAXException, ParserConfigurationException, TransformerException {
         return string(normaliseXmlString(input.getValue()), input.getNot());
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -283,13 +283,6 @@
                 <version>2.2.6</version>
             </dependency>
 
-            <!-- xml -->
-            <dependency>
-                <groupId>xerces</groupId>
-                <artifactId>xerces</artifactId>
-                <version>2.4.0</version>
-            </dependency>
-
             <!-- commons & guava -->
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
In my project I use mockServer and log4j2. When I upgraded log4j2 to 2.9.1 I got a nasty error "java.lang.AbstractMethodError: javax.xml.parsers.DocumentBuilderFactory.setFeature(Ljava/lang/String;Z)V" after some researches, that comes from old version of Xerces as the one used in mockServer.

So I had to do the same workaround as https://github.com/jamesdbloom/mockserver/issues/362.

I propose this pull request to remove Xerces dependency. As far as I understood mockServer's code I think this dependency is no longer required.