### PR TITLE
Decrease the object depth when finishing the base array

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/client/serialization/deserializers/body/BodyDTODeserializer.java
+++ b/mockserver-core/src/main/java/org/mockserver/client/serialization/deserializers/body/BodyDTODeserializer.java
@@ -121,6 +121,9 @@ public class BodyDTODeserializer extends StdDeserializer<BodyDTO> {
                             switch (token) {
                                 case START_ARRAY:
                                     break;
+                                case END_ARRAY:
+                                    objectDepth--;
+                                    break;
                                 case START_OBJECT:
                                     objectDepth++;
                                     parameterName = string("");

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/deserializers/body/BodyDTODeserializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/deserializers/body/BodyDTODeserializerTest.java
@@ -1271,6 +1271,34 @@ public class BodyDTODeserializerTest {
     }
 
     @Test
+    public void shouldParseJsonWithParameterBodyInWrongOrder() throws IOException {
+        // given
+        String json = ("{" + NEW_LINE +
+                "    \"httpRequest\": {" + NEW_LINE +
+                "        \"body\" : {" + NEW_LINE +
+                "            \"parameters\" : [ {" + NEW_LINE +
+                "                    \"name\" : \"parameterOneName\"," + NEW_LINE +
+                "                    \"values\" : [ \"parameterOneValueOne\" ]" + NEW_LINE +
+                "            } ]," + NEW_LINE +
+                "            \"type\" : \"PARAMETERS\"" + NEW_LINE +
+                "        }" + NEW_LINE +
+                "    }" + NEW_LINE +
+                "}");
+
+        // when
+        ExpectationDTO expectationDTO = ObjectMapperFactory.createObjectMapper().readValue(json, ExpectationDTO.class);
+
+        // then
+        assertEquals(new ExpectationDTO()
+                .setHttpRequest(
+                        new HttpRequestDTO()
+                                .setBody(new ParameterBodyDTO(new ParameterBody(
+                                        new Parameter("parameterOneName", "parameterOneValueOne")
+                                )))
+                ), expectationDTO);
+    }
+
+    @Test
     public void shouldParseJsonWithParameterBodyUsingParametersProperty() throws IOException {
         // given
         String json = ("{" + NEW_LINE +


### PR DESCRIPTION
The parameters is an array of objects, so when we hit end array it
should be the base array.  If this doesn't decrement the depth, the loop
will continue and the next getCurrentToken will take the "type" that is
next in the "body" hash and thus will ignore it until it hits the end of
the body that will finally decrement de object depth.  So everything
after "parameters" was curerntly ignored!

Fixes #371

============

I kind of think there should be an if objectDepth == 1 in there but i'm not familiar enough with the code or the contract to see if that is an actual case.   

Probably the correct way would be reverse the while into an unconditional one and increment the depth on START_ARRAY and decrement on END_ARRAY, but that would mean the first .nextToken() (ligne 114) would be inside the while loop and you would lose the isExpectedStartArrayToken() validation.   I thought there was a payload validation elsewhere so maybe this wouldn't be much of a deal to remove.   

In any case I did not feel comfortable enough to change the whole thing, i just fixed the bug and since all tests seems to pass it must not be bad :) 

Great test suite by the way!