### PR TITLE
Add .editorconfig support for codestyle.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*]
+charset=utf-8
+end_of_line=lf
+insert_final_newline=true
+indent_style=space
+indent_size=4


### PR DESCRIPTION
This project indents and styling differs from my default settings, so adding in an .editorconfig (http://editorconfig.org/) file.
This keeps the project specific formatting.
.editorconfig is adopted by a bunch of editors and IDEs, but I specifically use Intellij. 

