### PR TITLE
Fix non-convergent transitive dependencies.

### DIFF
--- a/mockserver-core/pom.xml
+++ b/mockserver-core/pom.xml
@@ -71,6 +71,12 @@
         <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-engine-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- json (object serialisation) -->
@@ -85,6 +91,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.skyscreamer</groupId>
@@ -95,6 +107,12 @@
         <dependency>
             <groupId>com.github.java-json-tools</groupId>
             <artifactId>json-schema-validator</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- xml -->
@@ -111,6 +129,12 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>


### PR DESCRIPTION
Mockserver has some [non-convergent transitive dependencies](https://maven.apache.org/enforcer/enforcer-rules/dependencyConvergence.html).

If there are some breaking public API changes that Mockserver uses and the manually excluded dependencies don't, this will break things. This is usually somewhat rare, especially when those dependencies follow semver.

We should be able to tell from the CI infrastructure if this breaks thing as it will trigger some NoClassDefFoundErrors, or similar exceptions.

The rationale for this PR is that, in one of my projects, I use the maven-enforcer-plugin `<dependencyConvergence/>` rule, and Mockserver is the only dependency (for my project) that doesn't have convergent transitive dependencies. Outside of the personal gain from this being merged, I think it is considered good practice for third party libraries to be non-convergence free.

Hopefully this makes sense, it's a somewhat obscure thing.