### PR TITLE
Add PATCH to CORS allow methods

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/cors/CORSHeaders.java
+++ b/mockserver-core/src/main/java/org/mockserver/cors/CORSHeaders.java
@@ -33,7 +33,7 @@ public class CORSHeaders {
         } else {
             setHeaderIfNotAlreadyExists(response, HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), ANY_ORIGIN);
         }
-        setHeaderIfNotAlreadyExists(response, HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString(), "CONNECT, DELETE, GET, HEAD, OPTIONS, POST, PUT, TRACE");
+        setHeaderIfNotAlreadyExists(response, HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString(), "CONNECT, DELETE, GET, HEAD, OPTIONS, POST, PUT, PATCH, TRACE");
         String headers = "Allow, Content-Encoding, Content-Length, Content-Type, ETag, Expires, Last-Modified, Location, Server, Vary";
         setHeaderIfNotAlreadyExists(response, HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS.toString(), headers);
         setHeaderIfNotAlreadyExists(response, HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS.toString(), headers);


### PR DESCRIPTION
This PR adds `PATCH` to the list of CORS allow methods. We're using the docker image and unless I'm mistaken, there's no way to disable CORS support for REST API.