### PR TITLE
Replace Guava's Charset with JDK builtin StandardCharsets.

### DIFF
--- a/mockserver-client-java/src/main/java/org/mockserver/client/MockServerClient.java
+++ b/mockserver-client-java/src/main/java/org/mockserver/client/MockServerClient.java
@@ -1,6 +1,5 @@
 package org.mockserver.client;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.SettableFuture;
 import org.apache.commons.lang3.StringUtils;
@@ -20,6 +19,7 @@ import org.mockserver.verify.VerificationSequence;
 import org.mockserver.verify.VerificationTimes;
 
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -189,7 +189,7 @@ public class MockServerClient implements java.io.Closeable {
      * Bind new ports to listen on
      */
     public List<Integer> bind(Integer... ports) {
-        String boundPorts = sendRequest(request().withMethod("PUT").withPath(calculatePath("bind")).withBody(portBindingSerializer.serialize(portBinding(ports)), Charsets.UTF_8)).getBodyAsString();
+        String boundPorts = sendRequest(request().withMethod("PUT").withPath(calculatePath("bind")).withBody(portBindingSerializer.serialize(portBinding(ports)), StandardCharsets.UTF_8)).getBodyAsString();
         return portBindingSerializer.deserialize(boundPorts).getPorts();
     }
 
@@ -238,7 +238,7 @@ public class MockServerClient implements java.io.Closeable {
      * @param httpRequest the http request that is matched against when deciding whether to clear each expectation if null all expectations are cleared
      */
     public MockServerClient clear(HttpRequest httpRequest) {
-        sendRequest(request().withMethod("PUT").withPath(calculatePath("clear")).withBody(httpRequest != null ? httpRequestSerializer.serialize(httpRequest) : "", Charsets.UTF_8));
+        sendRequest(request().withMethod("PUT").withPath(calculatePath("clear")).withBody(httpRequest != null ? httpRequestSerializer.serialize(httpRequest) : "", StandardCharsets.UTF_8));
         return clientClass.cast(this);
     }
 
@@ -249,7 +249,7 @@ public class MockServerClient implements java.io.Closeable {
      * @param type        the type to clear, EXPECTATION, LOG or BOTH
      */
     public MockServerClient clear(HttpRequest httpRequest, ClearType type) {
-        sendRequest(request().withMethod("PUT").withPath(calculatePath("clear")).withQueryStringParameter("type", type.name().toLowerCase()).withBody(httpRequest != null ? httpRequestSerializer.serialize(httpRequest) : "", Charsets.UTF_8));
+        sendRequest(request().withMethod("PUT").withPath(calculatePath("clear")).withQueryStringParameter("type", type.name().toLowerCase()).withBody(httpRequest != null ? httpRequestSerializer.serialize(httpRequest) : "", StandardCharsets.UTF_8));
         return clientClass.cast(this);
     }
 
@@ -276,7 +276,7 @@ public class MockServerClient implements java.io.Closeable {
         }
 
         VerificationSequence verificationSequence = new VerificationSequence().withRequests(httpRequests);
-        String result = sendRequest(request().withMethod("PUT").withPath(calculatePath("verifySequence")).withBody(verificationSequenceSerializer.serialize(verificationSequence), Charsets.UTF_8)).getBodyAsString();
+        String result = sendRequest(request().withMethod("PUT").withPath(calculatePath("verifySequence")).withBody(verificationSequenceSerializer.serialize(verificationSequence), StandardCharsets.UTF_8)).getBodyAsString();
 
         if (result != null && !result.isEmpty()) {
             throw new AssertionError(result);
@@ -314,7 +314,7 @@ public class MockServerClient implements java.io.Closeable {
         }
 
         Verification verification = verification().withRequest(httpRequest).withTimes(times);
-        String result = sendRequest(request().withMethod("PUT").withPath(calculatePath("verify")).withBody(verificationSerializer.serialize(verification), Charsets.UTF_8)).getBodyAsString();
+        String result = sendRequest(request().withMethod("PUT").withPath(calculatePath("verify")).withBody(verificationSerializer.serialize(verification), StandardCharsets.UTF_8)).getBodyAsString();
 
         if (result != null && !result.isEmpty()) {
             throw new AssertionError(result);
@@ -329,7 +329,7 @@ public class MockServerClient implements java.io.Closeable {
      */
     public MockServerClient verifyZeroInteractions() throws AssertionError {
         Verification verification = verification().withRequest(request()).withTimes(exactly(0));
-        String result = sendRequest(request().withMethod("PUT").withPath(calculatePath("verify")).withBody(verificationSerializer.serialize(verification), Charsets.UTF_8)).getBodyAsString();
+        String result = sendRequest(request().withMethod("PUT").withPath(calculatePath("verify")).withBody(verificationSerializer.serialize(verification), StandardCharsets.UTF_8)).getBodyAsString();
 
         if (result != null && !result.isEmpty()) {
             throw new AssertionError(result);
@@ -366,7 +366,7 @@ public class MockServerClient implements java.io.Closeable {
                 .withPath(calculatePath("retrieve"))
                 .withQueryStringParameter("type", RetrieveType.REQUESTS.name())
                 .withQueryStringParameter("format", format.name())
-                .withBody(httpRequest != null ? httpRequestSerializer.serialize(httpRequest) : "", Charsets.UTF_8)
+                .withBody(httpRequest != null ? httpRequestSerializer.serialize(httpRequest) : "", StandardCharsets.UTF_8)
         );
         return httpResponse.getBodyAsString();
     }
@@ -400,7 +400,7 @@ public class MockServerClient implements java.io.Closeable {
                 .withPath(calculatePath("retrieve"))
                 .withQueryStringParameter("type", RetrieveType.RECORDED_EXPECTATIONS.name())
                 .withQueryStringParameter("format", format.name())
-                .withBody(httpRequest != null ? httpRequestSerializer.serialize(httpRequest) : "", Charsets.UTF_8)
+                .withBody(httpRequest != null ? httpRequestSerializer.serialize(httpRequest) : "", StandardCharsets.UTF_8)
         );
         return httpResponse.getBodyAsString();
     }
@@ -417,7 +417,7 @@ public class MockServerClient implements java.io.Closeable {
                 .withMethod("PUT")
                 .withPath(calculatePath("retrieve"))
                 .withQueryStringParameter("type", RetrieveType.LOGS.name())
-                .withBody(httpRequest != null ? httpRequestSerializer.serialize(httpRequest) : "", Charsets.UTF_8)
+                .withBody(httpRequest != null ? httpRequestSerializer.serialize(httpRequest) : "", StandardCharsets.UTF_8)
         );
         return httpResponse.getBodyAsString();
     }
@@ -511,7 +511,7 @@ public class MockServerClient implements java.io.Closeable {
     }
 
     void sendExpectation(Expectation expectation) {
-        HttpResponse httpResponse = sendRequest(request().withMethod("PUT").withPath(calculatePath("expectation")).withBody(expectation != null ? expectationSerializer.serialize(expectation) : "", Charsets.UTF_8));
+        HttpResponse httpResponse = sendRequest(request().withMethod("PUT").withPath(calculatePath("expectation")).withBody(expectation != null ? expectationSerializer.serialize(expectation) : "", StandardCharsets.UTF_8));
         if (httpResponse != null && httpResponse.getStatusCode() != 201) {
             throw new ClientException(formatLogMessage("error:{}" + NEW_LINE + "while submitted expectation:{}", httpResponse.getBody(), expectation));
         }
@@ -546,7 +546,7 @@ public class MockServerClient implements java.io.Closeable {
                 .withPath(calculatePath("retrieve"))
                 .withQueryStringParameter("type", RetrieveType.ACTIVE_EXPECTATIONS.name())
                 .withQueryStringParameter("format", format.name())
-                .withBody(httpRequest != null ? httpRequestSerializer.serialize(httpRequest) : "", Charsets.UTF_8)
+                .withBody(httpRequest != null ? httpRequestSerializer.serialize(httpRequest) : "", StandardCharsets.UTF_8)
         );
         return httpResponse.getBodyAsString();
     }

--- a/mockserver-client-java/src/test/java/org/mockserver/client/MockServerClientIntegrationTest.java
+++ b/mockserver-client-java/src/test/java/org/mockserver/client/MockServerClientIntegrationTest.java
@@ -17,7 +17,7 @@ import org.mockserver.verify.VerificationTimes;
 
 import java.util.Arrays;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsCollectionContaining.hasItems;

--- a/mockserver-client-java/src/test/java/org/mockserver/client/MockServerClientTest.java
+++ b/mockserver-client-java/src/test/java/org/mockserver/client/MockServerClientTest.java
@@ -1,6 +1,5 @@
 package org.mockserver.client;
 
-import com.google.common.base.Charsets;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,9 +24,10 @@ import org.mockserver.verify.Verification;
 import org.mockserver.verify.VerificationSequence;
 import org.mockserver.verify.VerificationTimes;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.CREATED;
@@ -911,7 +911,7 @@ public class MockServerClientTest {
                 .withHeader(HOST.toString(), "localhost:" + 1080)
                 .withMethod("PUT")
                 .withPath("/clear")
-                .withBody(someRequestMatcher.toString(), Charsets.UTF_8),
+                .withBody(someRequestMatcher.toString(), StandardCharsets.UTF_8),
             20000,
             TimeUnit.MILLISECONDS
         );
@@ -935,7 +935,7 @@ public class MockServerClientTest {
                 .withMethod("PUT")
                 .withPath("/clear")
                 .withQueryStringParameter("type", "log")
-                .withBody(someRequestMatcher.toString(), Charsets.UTF_8),
+                .withBody(someRequestMatcher.toString(), StandardCharsets.UTF_8),
             20000,
             TimeUnit.MILLISECONDS
         );
@@ -953,7 +953,7 @@ public class MockServerClientTest {
                 .withHeader(HOST.toString(), "localhost:" + 1080)
                 .withMethod("PUT")
                 .withPath("/clear")
-                .withBody("", Charsets.UTF_8),
+                .withBody("", StandardCharsets.UTF_8),
             20000,
             TimeUnit.MILLISECONDS
         );
@@ -985,7 +985,7 @@ public class MockServerClientTest {
                 .withPath("/retrieve")
                 .withQueryStringParameter("type", RetrieveType.REQUESTS.name())
                 .withQueryStringParameter("format", Format.JSON.name())
-                .withBody(someRequestMatcher.toString(), Charsets.UTF_8),
+                .withBody(someRequestMatcher.toString(), StandardCharsets.UTF_8),
             20000,
             TimeUnit.MILLISECONDS);
         verify(mockHttpRequestSerializer).deserializeArray("body");
@@ -1009,7 +1009,7 @@ public class MockServerClientTest {
                 .withPath("/retrieve")
                 .withQueryStringParameter("type", RetrieveType.REQUESTS.name())
                 .withQueryStringParameter("format", Format.JSON.name())
-                .withBody("", Charsets.UTF_8),
+                .withBody("", StandardCharsets.UTF_8),
             20000,
             TimeUnit.MILLISECONDS
         );
@@ -1042,7 +1042,7 @@ public class MockServerClientTest {
                 .withPath("/retrieve")
                 .withQueryStringParameter("type", RetrieveType.ACTIVE_EXPECTATIONS.name())
                 .withQueryStringParameter("format", Format.JSON.name())
-                .withBody(someRequestMatcher.toString(), Charsets.UTF_8),
+                .withBody(someRequestMatcher.toString(), StandardCharsets.UTF_8),
             20000,
             TimeUnit.MILLISECONDS
         );
@@ -1067,7 +1067,7 @@ public class MockServerClientTest {
                 .withPath("/retrieve")
                 .withQueryStringParameter("type", RetrieveType.ACTIVE_EXPECTATIONS.name())
                 .withQueryStringParameter("format", Format.JSON.name())
-                .withBody("", Charsets.UTF_8),
+                .withBody("", StandardCharsets.UTF_8),
             20000,
             TimeUnit.MILLISECONDS
         );
@@ -1100,7 +1100,7 @@ public class MockServerClientTest {
                 .withPath("/retrieve")
                 .withQueryStringParameter("type", RetrieveType.RECORDED_EXPECTATIONS.name())
                 .withQueryStringParameter("format", Format.JSON.name())
-                .withBody(someRequestMatcher.toString(), Charsets.UTF_8),
+                .withBody(someRequestMatcher.toString(), StandardCharsets.UTF_8),
             20000,
             TimeUnit.MILLISECONDS
         );
@@ -1125,7 +1125,7 @@ public class MockServerClientTest {
                 .withPath("/retrieve")
                 .withQueryStringParameter("type", RetrieveType.RECORDED_EXPECTATIONS.name())
                 .withQueryStringParameter("format", Format.JSON.name())
-                .withBody("", Charsets.UTF_8),
+                .withBody("", StandardCharsets.UTF_8),
             20000,
             TimeUnit.MILLISECONDS
         );
@@ -1153,7 +1153,7 @@ public class MockServerClientTest {
                     .withHeader(HOST.toString(), "localhost:" + 1080)
                     .withMethod("PUT")
                     .withPath("/verifySequence")
-                    .withBody("verification_json", Charsets.UTF_8),
+                    .withBody("verification_json", StandardCharsets.UTF_8),
                 20000,
                 TimeUnit.MILLISECONDS
             );
@@ -1182,7 +1182,7 @@ public class MockServerClientTest {
                     .withHeader(HOST.toString(), "localhost:" + 1080)
                     .withMethod("PUT")
                     .withPath("/verifySequence")
-                    .withBody("verification_json", Charsets.UTF_8),
+                    .withBody("verification_json", StandardCharsets.UTF_8),
                 20000,
                 TimeUnit.MILLISECONDS
             );
@@ -1214,7 +1214,7 @@ public class MockServerClientTest {
                 .withHeader(HOST.toString(), "localhost:" + 1080)
                 .withMethod("PUT")
                 .withPath("/verifySequence")
-                .withBody("verification_json", Charsets.UTF_8),
+                .withBody("verification_json", StandardCharsets.UTF_8),
             20000,
             TimeUnit.MILLISECONDS
         );
@@ -1244,7 +1244,7 @@ public class MockServerClientTest {
                 .withHeader(HOST.toString(), "localhost:" + 1080)
                 .withMethod("PUT")
                 .withPath("/verify")
-                .withBody("verification_json", Charsets.UTF_8),
+                .withBody("verification_json", StandardCharsets.UTF_8),
             20000,
             TimeUnit.MILLISECONDS
         );
@@ -1271,7 +1271,7 @@ public class MockServerClientTest {
                     .withHeader(HOST.toString(), "localhost:" + 1080)
                     .withMethod("PUT")
                     .withPath("/verify")
-                    .withBody("verification_json", Charsets.UTF_8),
+                    .withBody("verification_json", StandardCharsets.UTF_8),
                 20000,
                 TimeUnit.MILLISECONDS
             );

--- a/mockserver-core/src/main/java/org/mockserver/client/serialization/Base64Converter.java
+++ b/mockserver-core/src/main/java/org/mockserver/client/serialization/Base64Converter.java
@@ -4,7 +4,7 @@ import org.mockserver.model.ObjectWithReflectiveEqualsHashCodeToString;
 
 import javax.xml.bind.DatatypeConverter;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * @author jamesdbloom

--- a/mockserver-core/src/main/java/org/mockserver/file/FileReader.java
+++ b/mockserver-core/src/main/java/org/mockserver/file/FileReader.java
@@ -1,9 +1,9 @@
 package org.mockserver.file;
 
-import com.google.common.base.Charsets;
 import org.apache.commons.io.IOUtils;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 
 /**
  * @author jamesdbloom
@@ -12,7 +12,7 @@ public class FileReader {
 
     public static String readFileFromClassPathOrPath(String filePath) {
         try {
-            return IOUtils.toString(openStreamToFileFromClassPathOrPath(filePath), Charsets.UTF_8.name());
+            return IOUtils.toString(openStreamToFileFromClassPathOrPath(filePath), StandardCharsets.UTF_8.name());
         } catch (IOException ioe) {
             throw new RuntimeException("Exception while loading \"" + filePath + "\"", ioe);
         }

--- a/mockserver-core/src/main/java/org/mockserver/logging/LoggingHandler.java
+++ b/mockserver-core/src/main/java/org/mockserver/logging/LoggingHandler.java
@@ -1,6 +1,5 @@
 package org.mockserver.logging;
 
-import com.google.common.base.Charsets;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.ChannelDuplexHandler;
@@ -12,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.SocketAddress;
+import java.nio.charset.StandardCharsets;
 
 import static org.mockserver.character.Character.NEW_LINE;
 
@@ -220,7 +220,7 @@ public class LoggingHandler extends ChannelDuplexHandler {
             if (relIdxMod16 == 15) {
                 dump.append(" |");
                 if (i > 15 && buf.readableBytes() > i) {
-                    dump.append(buf.toString(i - 15, 16, Charsets.UTF_8).replaceAll("" + NEW_LINE, "/").replaceAll("\r", "/"));
+                    dump.append(buf.toString(i - 15, 16, StandardCharsets.UTF_8).replaceAll("" + NEW_LINE, "/").replaceAll("\r", "/"));
                 } else {
                     for (int j = i - 15; j <= i; j++) {
                         dump.append(BYTE2CHAR[buf.getUnsignedByte(j)]);

--- a/mockserver-core/src/main/java/org/mockserver/matchers/HttpRequestMatcher.java
+++ b/mockserver-core/src/main/java/org/mockserver/matchers/HttpRequestMatcher.java
@@ -2,7 +2,6 @@ package org.mockserver.matchers;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 import org.mockserver.client.serialization.ObjectMapperFactory;
 import org.mockserver.client.serialization.model.*;
@@ -12,6 +11,8 @@ import org.mockserver.model.*;
 
 import static org.mockserver.character.Character.NEW_LINE;
 import static org.mockserver.model.NottableString.string;
+
+import java.nio.charset.StandardCharsets;
 
 /**
  * @author jamesdbloom
@@ -219,7 +220,7 @@ public class HttpRequestMatcher extends NotMatcher<HttpRequest> {
 
     private boolean bodyMatches(HttpRequest context, HttpRequest request) {
         boolean bodyMatches = true;
-        String bodyAsString = request.getBody() != null ? new String(request.getBody().getRawBytes(), request.getBody().getCharset(Charsets.UTF_8)) : "";
+        String bodyAsString = request.getBody() != null ? new String(request.getBody().getRawBytes(), request.getBody().getCharset(StandardCharsets.UTF_8)) : "";
         if (!bodyAsString.isEmpty()) {
             if (bodyMatcher instanceof BinaryMatcher) {
                 bodyMatches = matches(context, bodyMatcher, request.getBodyAsRawBytes());

--- a/mockserver-core/src/main/java/org/mockserver/model/Body.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/Body.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.nio.charset.Charset;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * @author jamesdbloom

--- a/mockserver-core/src/main/java/org/mockserver/model/ParameterBody.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/ParameterBody.java
@@ -1,10 +1,10 @@
 package org.mockserver.model;
 
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
@@ -58,7 +58,7 @@ public class ParameterBody extends BodyWithContentType<List<Parameter>> {
                     body.append(parameter.getName().getValue());
                     body.append('=');
                     try {
-                        body.append(URLEncoder.encode(value, Charsets.UTF_8.name()));
+                        body.append(URLEncoder.encode(value, StandardCharsets.UTF_8.name()));
                     } catch (UnsupportedEncodingException uee) {
                         throw new RuntimeException("UnsupportedEncodingException while encoding body parameters for " + parameters, uee);
                     }

--- a/mockserver-core/src/main/java/org/mockserver/streams/IOStreamUtils.java
+++ b/mockserver-core/src/main/java/org/mockserver/streams/IOStreamUtils.java
@@ -1,6 +1,5 @@
 package org.mockserver.streams;
 
-import com.google.common.base.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.mockserver.logging.MockServerLogger;
 
@@ -13,7 +12,7 @@ import java.io.OutputStream;
 import java.net.Socket;
 import java.nio.ByteBuffer;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.mockserver.character.Character.NEW_LINE;
 
 /**
@@ -48,7 +47,7 @@ public class IOStreamUtils {
 
     public static String readInputStreamToString(ServletRequest request) {
         try {
-            return IOUtils.toString(request.getInputStream(), Charsets.UTF_8.name());
+            return IOUtils.toString(request.getInputStream(), UTF_8.name());
         } catch (IOException ioe) {
             MOCK_SERVER_LOGGER.error("IOException while reading HttpServletRequest input stream", ioe);
             throw new RuntimeException("IOException while reading HttpServletRequest input stream", ioe);

--- a/mockserver-core/src/main/java/org/mockserver/url/URLEncoder.java
+++ b/mockserver-core/src/main/java/org/mockserver/url/URLEncoder.java
@@ -1,10 +1,10 @@
 package org.mockserver.url;
 
-import com.google.common.base.Charsets;
 import org.mockserver.logging.MockServerLogger;
 
 import java.io.ByteArrayOutputStream;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import static org.slf4j.event.Level.TRACE;
@@ -28,7 +28,8 @@ public class URLEncoder {
 
     public static String encodeURL(String input) {
         try {
-            byte[] sourceBytes = URLDecoder.decode(input, Charsets.UTF_8.name()).getBytes(Charsets.UTF_8);
+            byte[] sourceBytes = URLDecoder.decode(input, StandardCharsets.UTF_8.name())
+                    .getBytes(StandardCharsets.UTF_8);
             ByteArrayOutputStream bos = new ByteArrayOutputStream(sourceBytes.length);
             for (byte aSource : sourceBytes) {
                 int b = aSource;
@@ -46,7 +47,7 @@ public class URLEncoder {
                     bos.write(hex2);
                 }
             }
-            return new String(bos.toByteArray(), Charsets.UTF_8);
+            return new String(bos.toByteArray(), StandardCharsets.UTF_8);
         } catch (Exception e) {
             MOCK_SERVER_LOGGER.trace("Exception while decoding or encoding url [" + input + "]", e);
             return input;

--- a/mockserver-core/src/test/java/org/mockserver/client/netty/codec/MockServerRequestEncoderBasicMappingTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/netty/codec/MockServerRequestEncoderBasicMappingTest.java
@@ -1,6 +1,5 @@
 package org.mockserver.client.netty.codec;
 
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -11,11 +10,12 @@ import org.mockserver.model.Cookie;
 import org.mockserver.model.Header;
 import org.mockserver.model.HttpRequest;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -187,7 +187,7 @@ public class MockServerRequestEncoderBasicMappingTest {
 
         // then
         FullHttpRequest fullHttpRequest = (FullHttpRequest) output.get(0);
-        assertThat(fullHttpRequest.content().toString(Charsets.UTF_8), is("somebody"));
+        assertThat(fullHttpRequest.content().toString(StandardCharsets.UTF_8), is("somebody"));
         assertThat(fullHttpRequest.headers().get(CONTENT_TYPE), nullValue());
     }
 
@@ -201,7 +201,7 @@ public class MockServerRequestEncoderBasicMappingTest {
 
         // then
         FullHttpRequest fullHttpRequest = (FullHttpRequest) output.get(0);
-        assertThat(fullHttpRequest.content().toString(Charsets.UTF_8), is("somebody"));
+        assertThat(fullHttpRequest.content().toString(StandardCharsets.UTF_8), is("somebody"));
         assertThat(fullHttpRequest.headers().get(CONTENT_TYPE), is(MediaType.HTML_UTF_8.toString()));
     }
 
@@ -243,7 +243,7 @@ public class MockServerRequestEncoderBasicMappingTest {
 
         // then
         FullHttpRequest fullHttpRequest = (FullHttpRequest) output.get(0);
-        assertThat(fullHttpRequest.content().toString(Charsets.UTF_8), is(""));
+        assertThat(fullHttpRequest.content().toString(StandardCharsets.UTF_8), is(""));
     }
 
 }

--- a/mockserver-core/src/test/java/org/mockserver/client/netty/codec/MockServerRequestEncoderContentTypeTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/netty/codec/MockServerRequestEncoderContentTypeTest.java
@@ -1,6 +1,5 @@
 package org.mockserver.client.netty.codec;
 
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import io.netty.handler.codec.http.FullHttpRequest;
 import org.hamcrest.collection.IsEmptyCollection;
@@ -10,10 +9,11 @@ import org.mockserver.mappers.ContentTypeMapper;
 import org.mockserver.model.Header;
 import org.mockserver.model.HttpRequest;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -102,43 +102,43 @@ public class MockServerRequestEncoderContentTypeTest {
     @Test
     public void shouldDecodeBodyWithUTF8ContentType() {
         // given
-        httpRequest.withBody("avro işarəsi: \u20AC", Charsets.UTF_8);
-        httpRequest.withHeader(new Header(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(Charsets.UTF_8).toString()));
+        httpRequest.withBody("avro işarəsi: \u20AC", StandardCharsets.UTF_8);
+        httpRequest.withHeader(new Header(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_8).toString()));
 
         // when
         new MockServerRequestEncoder().encode(null, httpRequest, output);
 
         // then
         FullHttpRequest fullHttpRequest = (FullHttpRequest) output.get(0);
-        assertThat(fullHttpRequest.content().toString(Charsets.UTF_8), is("avro işarəsi: \u20AC"));
+        assertThat(fullHttpRequest.content().toString(StandardCharsets.UTF_8), is("avro işarəsi: \u20AC"));
     }
 
     @Test
     public void shouldDecodeBodyWithUTF16ContentType() {
         // given
-        httpRequest.withBody("我说中国话", Charsets.UTF_16);
-        httpRequest.withHeader(new Header(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(Charsets.UTF_16).toString()));
+        httpRequest.withBody("我说中国话", StandardCharsets.UTF_16);
+        httpRequest.withHeader(new Header(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_16).toString()));
 
         // when
         new MockServerRequestEncoder().encode(null, httpRequest, output);
 
         // then
         FullHttpRequest fullHttpRequest = (FullHttpRequest) output.get(0);
-        assertThat(fullHttpRequest.content().toString(Charsets.UTF_16), is("我说中国话"));
+        assertThat(fullHttpRequest.content().toString(StandardCharsets.UTF_16), is("我说中国话"));
     }
 
     @Test
     public void shouldEncodeStringBodyWithCharset() {
         // given
-        httpRequest.withBody("我说中国话", Charsets.UTF_16);
+        httpRequest.withBody("我说中国话", StandardCharsets.UTF_16);
 
         // when
         new MockServerRequestEncoder().encode(null, httpRequest, output);
 
         // then
         FullHttpRequest fullHttpRequest = (FullHttpRequest) output.get(0);
-        assertThat(fullHttpRequest.content().toString(Charsets.UTF_16), is("我说中国话"));
-        assertThat(fullHttpRequest.headers().get(CONTENT_TYPE), is(MediaType.create("text", "plain").withCharset(Charsets.UTF_16).toString()));
+        assertThat(fullHttpRequest.content().toString(StandardCharsets.UTF_16), is("我说中国话"));
+        assertThat(fullHttpRequest.headers().get(CONTENT_TYPE), is(MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_16).toString()));
     }
 
     @Test
@@ -151,36 +151,36 @@ public class MockServerRequestEncoderContentTypeTest {
 
         // then
         FullHttpRequest fullHttpResponse = (FullHttpRequest) output.get(0);
-        assertThat(new String(fullHttpResponse.content().array(), Charsets.UTF_8), is("{ \"some_field\": \"我说中国话\" }"));
+        assertThat(new String(fullHttpResponse.content().array(), StandardCharsets.UTF_8), is("{ \"some_field\": \"我说中国话\" }"));
         assertThat(fullHttpResponse.headers().get(CONTENT_TYPE), is(MediaType.JSON_UTF_8.toString()));
     }
 
     @Test
     public void shouldEncodeUTF8JsonBodyWithCharset() {
         // given
-        httpRequest.withBody(json("{ \"some_field\": \"我说中国话\" }", Charsets.UTF_8));
+        httpRequest.withBody(json("{ \"some_field\": \"我说中国话\" }", StandardCharsets.UTF_8));
 
         // when
         new MockServerRequestEncoder().encode(null, httpRequest, output);
 
         // then
         FullHttpRequest fullHttpResponse = (FullHttpRequest) output.get(0);
-        assertThat(new String(fullHttpResponse.content().array(), Charsets.UTF_8), is("{ \"some_field\": \"我说中国话\" }"));
+        assertThat(new String(fullHttpResponse.content().array(), StandardCharsets.UTF_8), is("{ \"some_field\": \"我说中国话\" }"));
         assertThat(fullHttpResponse.headers().get(CONTENT_TYPE), is(MediaType.JSON_UTF_8.toString()));
     }
 
     @Test
     public void shouldPreferStringBodyCharacterSet() {
         // given
-        httpRequest.withBody("avro işarəsi: \u20AC", Charsets.UTF_16);
-        httpRequest.withHeader(new Header(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(Charsets.US_ASCII).toString()));
+        httpRequest.withBody("avro işarəsi: \u20AC", StandardCharsets.UTF_16);
+        httpRequest.withHeader(new Header(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(StandardCharsets.US_ASCII).toString()));
 
         // when
         new MockServerRequestEncoder().encode(null, httpRequest, output);
 
         // then
         FullHttpRequest fullHttpRequest = (FullHttpRequest) output.get(0);
-        assertThat(fullHttpRequest.content().toString(Charsets.UTF_16), is("avro işarəsi: \u20AC"));
+        assertThat(fullHttpRequest.content().toString(StandardCharsets.UTF_16), is("avro işarəsi: \u20AC"));
     }
 
     @Test
@@ -222,7 +222,7 @@ public class MockServerRequestEncoderContentTypeTest {
     @Test
     public void shouldReturnContentTypeForStringBodyWithCharset() {
         // given - a request & response
-        httpRequest.withBody(exact("somebody", Charsets.UTF_16));
+        httpRequest.withBody(exact("somebody", StandardCharsets.UTF_16));
 
         // when
         new MockServerRequestEncoder().encode(null, httpRequest, output);

--- a/mockserver-core/src/test/java/org/mockserver/client/netty/codec/MockServerResponseDecoderTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/netty/codec/MockServerResponseDecoderTest.java
@@ -1,6 +1,5 @@
 package org.mockserver.client.netty.codec;
 
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.*;
@@ -12,10 +11,11 @@ import org.mockserver.model.Cookie;
 import org.mockserver.model.Header;
 import org.mockserver.model.HttpResponse;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -126,8 +126,8 @@ public class MockServerResponseDecoderTest {
     @Test
     public void shouldDecodeUTF16Body() {
         // given
-        fullHttpResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, Unpooled.wrappedBuffer("我说中国话".getBytes(Charsets.UTF_16)));
-        fullHttpResponse.headers().add(CONTENT_TYPE, MediaType.create("text", "plain").withCharset(Charsets.UTF_16).toString());
+        fullHttpResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, Unpooled.wrappedBuffer("我说中国话".getBytes(StandardCharsets.UTF_16)));
+        fullHttpResponse.headers().add(CONTENT_TYPE, MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_16).toString());
 
         // when
         mockServerResponseDecoder.decode(null, fullHttpResponse, output);

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/Base64ConverterTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/Base64ConverterTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import javax.xml.bind.DatatypeConverter;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/ExpectationSerializerIntegrationTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/ExpectationSerializerIntegrationTest.java
@@ -13,7 +13,7 @@ import org.mockserver.model.*;
 
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/ExpectationWithErrorSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/ExpectationWithErrorSerializerTest.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThat;

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/deserializers/body/BodyDTODeserializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/deserializers/body/BodyDTODeserializerTest.java
@@ -1,6 +1,5 @@
 package org.mockserver.client.serialization.deserializers.body;
 
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import org.apache.commons.text.StringEscapeUtils;
 import org.junit.Test;
@@ -11,8 +10,9 @@ import org.mockserver.model.*;
 
 import javax.xml.bind.DatatypeConverter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.mockserver.character.Character.NEW_LINE;
 import static org.mockserver.model.HttpRequest.request;
@@ -903,7 +903,7 @@ public class BodyDTODeserializerTest {
             "    \"httpRequest\": {" + NEW_LINE +
             "        \"body\" : {" + NEW_LINE +
             "            \"type\" : \"JSON\"," + NEW_LINE +
-            "            \"charset\" : \"" + Charsets.ISO_8859_1 + "\"," + NEW_LINE +
+            "            \"charset\" : \"" + StandardCharsets.ISO_8859_1 + "\"," + NEW_LINE +
             "            \"json\" : \"{'employees':[{'firstName':'John', 'lastName':'Doe'}]}\"" + NEW_LINE +
             "        }" + NEW_LINE +
             "    }" + NEW_LINE +
@@ -916,7 +916,7 @@ public class BodyDTODeserializerTest {
         assertEquals(new ExpectationDTO()
             .setHttpRequest(
                 new HttpRequestDTO()
-                    .setBody(new JsonBodyDTO(new JsonBody("{'employees':[{'firstName':'John', 'lastName':'Doe'}]}", MediaType.JSON_UTF_8.withCharset(Charsets.ISO_8859_1), MatchType.ONLY_MATCHING_FIELDS)))
+                    .setBody(new JsonBodyDTO(new JsonBody("{'employees':[{'firstName':'John', 'lastName':'Doe'}]}", MediaType.JSON_UTF_8.withCharset(StandardCharsets.ISO_8859_1), MatchType.ONLY_MATCHING_FIELDS)))
             ), expectationDTO);
     }
 
@@ -1277,7 +1277,7 @@ public class BodyDTODeserializerTest {
         String json = ("{" + NEW_LINE +
             "    \"httpRequest\": {" + NEW_LINE +
             "        \"body\" : {" + NEW_LINE +
-            "            \"charset\" : \"" + Charsets.US_ASCII + "\"," + NEW_LINE +
+            "            \"charset\" : \"" + StandardCharsets.US_ASCII + "\"," + NEW_LINE +
             "            \"xml\" : \"<some><xml></xml></some>\"" + NEW_LINE +
             "        }" + NEW_LINE +
             "    }" + NEW_LINE +
@@ -1290,7 +1290,7 @@ public class BodyDTODeserializerTest {
         assertEquals(new ExpectationDTO()
             .setHttpRequest(
                 new HttpRequestDTO()
-                    .setBody(new XmlBodyDTO(new XmlBody("<some><xml></xml></some>", MediaType.APPLICATION_XML_UTF_8.withCharset(Charsets.US_ASCII))))
+                    .setBody(new XmlBodyDTO(new XmlBody("<some><xml></xml></some>", MediaType.APPLICATION_XML_UTF_8.withCharset(StandardCharsets.US_ASCII))))
             ), expectationDTO);
     }
 

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/java/ExpectationToJavaSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/java/ExpectationToJavaSerializerTest.java
@@ -10,7 +10,7 @@ import org.mockserver.model.*;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.mockserver.character.Character.NEW_LINE;
 import static org.mockserver.matchers.TimeToLive.unlimited;

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/java/HttpErrorToJavaSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/java/HttpErrorToJavaSerializerTest.java
@@ -7,7 +7,7 @@ import org.mockserver.model.HttpError;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.mockserver.character.Character.NEW_LINE;
 

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/java/HttpRequestToJavaSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/java/HttpRequestToJavaSerializerTest.java
@@ -8,7 +8,7 @@ import org.mockserver.model.*;
 import java.io.IOException;
 import java.util.Arrays;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.mockserver.character.Character.NEW_LINE;
 

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/java/HttpResponseToJavaSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/java/HttpResponseToJavaSerializerTest.java
@@ -9,7 +9,7 @@ import org.mockserver.model.HttpResponse;
 
 import java.io.IOException;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.mockserver.character.Character.NEW_LINE;
 import static org.mockserver.model.BinaryBody.binary;

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/model/ExpectationDTOTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/model/ExpectationDTOTest.java
@@ -6,7 +6,7 @@ import org.mockserver.matchers.Times;
 import org.mockserver.mock.Expectation;
 import org.mockserver.model.*;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/model/HttpErrorDTOTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/model/HttpErrorDTOTest.java
@@ -6,7 +6,7 @@ import org.mockserver.model.HttpError;
 
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/model/JsonBodyDTOTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/model/JsonBodyDTOTest.java
@@ -1,17 +1,17 @@
 package org.mockserver.client.serialization.model;
 
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import org.junit.Test;
 import org.mockserver.model.Body;
 import org.mockserver.model.JsonBody;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.mockserver.matchers.MatchType.ONLY_MATCHING_FIELDS;
 import static org.mockserver.matchers.MatchType.STRICT;
-
 
 /**
  * @author jamesdbloom
@@ -45,7 +45,7 @@ public class JsonBodyDTOTest {
     @Test
     public void shouldReturnValuesSetInConstructorWithMatchTypeAndCharset() {
         // when
-        JsonBodyDTO jsonBody = new JsonBodyDTO(new JsonBody("some_body", Charsets.UTF_16, STRICT));
+        JsonBodyDTO jsonBody = new JsonBodyDTO(new JsonBody("some_body", StandardCharsets.UTF_16, STRICT));
 
         // then
         assertThat(jsonBody.getJson(), is("some_body"));
@@ -93,7 +93,7 @@ public class JsonBodyDTOTest {
     @Test
     public void shouldBuildCorrectObjectWithMatchTypeAndCharset() {
         // when
-        JsonBody jsonBody = new JsonBodyDTO(new JsonBody("some_body", Charsets.UTF_16, STRICT)).buildObject();
+        JsonBody jsonBody = new JsonBodyDTO(new JsonBody("some_body", StandardCharsets.UTF_16, STRICT)).buildObject();
 
         // then
         assertThat(jsonBody.getValue(), is("some_body"));

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/model/StringBodyDTOTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/model/StringBodyDTOTest.java
@@ -1,10 +1,11 @@
 package org.mockserver.client.serialization.model;
 
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import org.junit.Test;
 import org.mockserver.model.Body;
 import org.mockserver.model.StringBody;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
@@ -44,7 +45,7 @@ public class StringBodyDTOTest {
     @Test
     public void shouldReturnValuesSetInConstructorWithCharset() {
         // when
-        StringBodyDTO stringBody = new StringBodyDTO(new StringBody("some_body", Charsets.UTF_8));
+        StringBodyDTO stringBody = new StringBodyDTO(new StringBody("some_body", StandardCharsets.UTF_8));
 
         // then
         assertThat(stringBody.getString(), is("some_body"));
@@ -66,7 +67,7 @@ public class StringBodyDTOTest {
     @Test
     public void shouldBuildCorrectObject() {
         // when
-        StringBody stringBody = new StringBodyDTO(new StringBody("some_body", true, Charsets.UTF_8)).buildObject();
+        StringBody stringBody = new StringBodyDTO(new StringBody("some_body", true, StandardCharsets.UTF_8)).buildObject();
 
         // then
         assertThat(stringBody.getValue(), is("some_body"));
@@ -79,13 +80,13 @@ public class StringBodyDTOTest {
     public void shouldReturnCorrectObjectFromStaticExactBuilder() {
         assertThat(exact("some_body"), is(new StringBody("some_body", false)));
         assertThat(exact("some_body"), is(new StringBody("some_body")));
-        assertThat(exact("some_body", Charsets.UTF_16), is(new StringBody("some_body", false, Charsets.UTF_16)));
-        assertThat(exact("some_body", Charsets.UTF_16), is(new StringBody("some_body", Charsets.UTF_16)));
+        assertThat(exact("some_body", StandardCharsets.UTF_16), is(new StringBody("some_body", false, StandardCharsets.UTF_16)));
+        assertThat(exact("some_body", StandardCharsets.UTF_16), is(new StringBody("some_body", StandardCharsets.UTF_16)));
     }
 
     @Test
     public void shouldReturnCorrectObjectFromStaticSubStringBuilder() {
         assertThat(subString("some_body"), is(new StringBody("some_body", true)));
-        assertThat(subString("some_body", Charsets.UTF_16), is(new StringBody("some_body", true, Charsets.UTF_16)));
+        assertThat(subString("some_body", StandardCharsets.UTF_16), is(new StringBody("some_body", true, StandardCharsets.UTF_16)));
     }
 }

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/serializers/body/BinaryBodyDTOSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/serializers/body/BinaryBodyDTOSerializerTest.java
@@ -8,7 +8,7 @@ import org.mockserver.client.serialization.ObjectMapperFactory;
 import org.mockserver.client.serialization.model.BinaryBodyDTO;
 import org.mockserver.model.BinaryBody;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/serializers/body/BinaryBodySerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/serializers/body/BinaryBodySerializerTest.java
@@ -1,16 +1,14 @@
 package org.mockserver.client.serialization.serializers.body;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import org.junit.Test;
 import org.mockserver.client.serialization.ObjectMapperFactory;
 import org.mockserver.model.BinaryBody;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static org.mockserver.model.Not.not;
 
 public class BinaryBodySerializerTest {
 

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/serializers/body/JsonBodyDTOSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/serializers/body/JsonBodyDTOSerializerTest.java
@@ -1,13 +1,14 @@
 package org.mockserver.client.serialization.serializers.body;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import org.junit.Test;
 import org.mockserver.client.serialization.ObjectMapperFactory;
 import org.mockserver.client.serialization.model.JsonBodyDTO;
 import org.mockserver.matchers.MatchType;
 import org.mockserver.model.JsonBody;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -34,7 +35,7 @@ public class JsonBodyDTOSerializerTest {
 
     @Test
     public void shouldSerializeJsonBodyWithNoneDefaultMatchTypeAndCharset() throws JsonProcessingException {
-        assertThat(ObjectMapperFactory.createObjectMapper().writeValueAsString(new JsonBodyDTO(new JsonBody("{fieldOne: \"valueOne\", \"fieldTwo\": \"valueTwo\"}", Charsets.UTF_16, MatchType.STRICT))),
+        assertThat(ObjectMapperFactory.createObjectMapper().writeValueAsString(new JsonBodyDTO(new JsonBody("{fieldOne: \"valueOne\", \"fieldTwo\": \"valueTwo\"}", StandardCharsets.UTF_16, MatchType.STRICT))),
                 is("{\"contentType\":\"application/json; charset=utf-16\",\"type\":\"JSON\",\"json\":\"{fieldOne: \\\"valueOne\\\", \\\"fieldTwo\\\": \\\"valueTwo\\\"}\",\"matchType\":\"STRICT\"}"));
     }
 

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/serializers/body/JsonBodySerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/serializers/body/JsonBodySerializerTest.java
@@ -1,11 +1,12 @@
 package org.mockserver.client.serialization.serializers.body;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import org.junit.Test;
 import org.mockserver.client.serialization.ObjectMapperFactory;
 import org.mockserver.matchers.MatchType;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -61,7 +62,7 @@ public class JsonBodySerializerTest {
 
     @Test
     public void shouldSerializeJsonBodyWithNoneDefaultMatchTypeAndCharset() throws JsonProcessingException {
-        assertThat(ObjectMapperFactory.createObjectMapper().writeValueAsString(json("{fieldOne: \"valueOne\", \"fieldTwo\": \"valueTwo\"}", Charsets.UTF_16, MatchType.STRICT)),
+        assertThat(ObjectMapperFactory.createObjectMapper().writeValueAsString(json("{fieldOne: \"valueOne\", \"fieldTwo\": \"valueTwo\"}", StandardCharsets.UTF_16, MatchType.STRICT)),
                 is("{\"contentType\":\"application/json; charset=utf-16\",\"type\":\"JSON\",\"json\":\"{fieldOne: \\\"valueOne\\\", \\\"fieldTwo\\\": \\\"valueTwo\\\"}\",\"matchType\":\"STRICT\"}"));
     }
 

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/serializers/body/StringBodyDTOSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/serializers/body/StringBodyDTOSerializerTest.java
@@ -1,7 +1,6 @@
 package org.mockserver.client.serialization.serializers.body;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import org.junit.Test;
 import org.mockserver.client.serialization.ObjectMapperFactory;

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/serializers/body/StringBodySerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/serializers/body/StringBodySerializerTest.java
@@ -1,12 +1,13 @@
 package org.mockserver.client.serialization.serializers.body;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import org.junit.Test;
 import org.mockserver.client.serialization.ObjectMapperFactory;
 import org.mockserver.client.serialization.model.StringBodyDTO;
 import org.mockserver.model.StringBody;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -30,7 +31,7 @@ public class StringBodySerializerTest {
 
     @Test
     public void shouldSerializeStringBodyWithCharset() throws JsonProcessingException {
-        assertThat(ObjectMapperFactory.createObjectMapper().writeValueAsString(new StringBody("string_body", Charsets.UTF_16)),
+        assertThat(ObjectMapperFactory.createObjectMapper().writeValueAsString(new StringBody("string_body", StandardCharsets.UTF_16)),
                 is("{\"type\":\"STRING\",\"string\":\"string_body\",\"contentType\":\"text/plain; charset=utf-16\"}"));
     }
 
@@ -48,7 +49,7 @@ public class StringBodySerializerTest {
 
     @Test
     public void shouldSerializeStringBodyWithCharsetAndNot() throws JsonProcessingException {
-        assertThat(ObjectMapperFactory.createObjectMapper().writeValueAsString(not(new StringBody("string_body", Charsets.UTF_16))),
+        assertThat(ObjectMapperFactory.createObjectMapper().writeValueAsString(not(new StringBody("string_body", StandardCharsets.UTF_16))),
                 is("{\"not\":true,\"type\":\"STRING\",\"string\":\"string_body\",\"contentType\":\"text/plain; charset=utf-16\"}"));
     }
 

--- a/mockserver-core/src/test/java/org/mockserver/client/serialization/serializers/body/XmlBodySerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/client/serialization/serializers/body/XmlBodySerializerTest.java
@@ -1,13 +1,14 @@
 package org.mockserver.client.serialization.serializers.body;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import org.junit.Test;
 import org.mockserver.client.serialization.ObjectMapperFactory;
 import org.mockserver.matchers.MatchType;
 import org.mockserver.model.JsonBody;
 import org.mockserver.model.XmlBody;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -35,7 +36,7 @@ public class XmlBodySerializerTest {
 
     @Test
     public void shouldSerializeXmlBodyWithCharsetAndNot() throws JsonProcessingException {
-        assertThat(ObjectMapperFactory.createObjectMapper().writeValueAsString(not(new XmlBody("<some><xml></xml></some>", Charsets.UTF_16))),
+        assertThat(ObjectMapperFactory.createObjectMapper().writeValueAsString(not(new XmlBody("<some><xml></xml></some>", StandardCharsets.UTF_16))),
                 is("{\"not\":true,\"contentType\":\"application/xml; charset=utf-16\",\"type\":\"XML\",\"xml\":\"<some><xml></xml></some>\"}"));
     }
 

--- a/mockserver-core/src/test/java/org/mockserver/mappers/ContentTypeMapperTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/mappers/ContentTypeMapperTest.java
@@ -1,6 +1,5 @@
 package org.mockserver.mappers;
 
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMessage;
@@ -9,6 +8,7 @@ import org.junit.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
@@ -124,10 +124,10 @@ public class ContentTypeMapperTest {
     @Test
     public void shouldDetermineCharsetFromResponseContentType() {
         // when
-        Charset charset = ContentTypeMapper.getCharsetFromContentTypeHeader(MediaType.create("text", "plain").withCharset(Charsets.UTF_16).toString());
+        Charset charset = ContentTypeMapper.getCharsetFromContentTypeHeader(MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_16).toString());
 
         // then
-        assertThat(charset, is(Charsets.UTF_16));
+        assertThat(charset, is(StandardCharsets.UTF_16));
     }
 
     @Test

--- a/mockserver-core/src/test/java/org/mockserver/mappers/HttpServletRequestToMockServerRequestDecoderTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/mappers/HttpServletRequestToMockServerRequestDecoderTest.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Enumeration;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/mockserver-core/src/test/java/org/mockserver/mappers/MockServerResponseToHttpServletResponseEncoderContentTypeTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/mappers/MockServerResponseToHttpServletResponseEncoderContentTypeTest.java
@@ -1,6 +1,5 @@
 package org.mockserver.mappers;
 
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import org.junit.Test;
 import org.mockserver.model.Cookie;
@@ -13,6 +12,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -51,7 +51,7 @@ public class MockServerResponseToHttpServletResponseEncoderContentTypeTest {
     @Test
     public void shouldReturnContentTypeForStringBodyWithCharset() {
         // given
-        HttpResponse httpResponse = response().withBody(exact("somebody", Charsets.US_ASCII));
+        HttpResponse httpResponse = response().withBody(exact("somebody", StandardCharsets.US_ASCII));
         MockHttpServletResponse httpServletResponse = new MockHttpServletResponse();
 
         // when

--- a/mockserver-core/src/test/java/org/mockserver/matchers/BinaryMatcherTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/matchers/BinaryMatcherTest.java
@@ -3,7 +3,7 @@ package org.mockserver.matchers;
 import org.junit.Test;
 import org.mockserver.logging.MockServerLogger;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockserver.matchers.NotMatcher.not;

--- a/mockserver-core/src/test/java/org/mockserver/matchers/HttpRequestMatcherTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/matchers/HttpRequestMatcherTest.java
@@ -1,6 +1,5 @@
 package org.mockserver.matchers;
 
-import com.google.common.base.Charsets;
 import org.junit.Test;
 import org.mockserver.client.serialization.model.*;
 import org.mockserver.logging.MockServerLogger;
@@ -8,7 +7,9 @@ import org.mockserver.mock.HttpStateHandler;
 import org.mockserver.model.*;
 import org.slf4j.LoggerFactory;
 
-import static com.google.common.base.Charsets.UTF_8;
+import java.nio.charset.StandardCharsets;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -371,7 +372,7 @@ public class HttpRequestMatcherTest {
 
     @Test
     public void matchesMatchingBodyWithCharset() {
-        assertTrue(new HttpRequestMatcher(new HttpRequest().withBody(new StringBody("我说中国话", Charsets.UTF_16)), mockServerLogger).matches(null, new HttpRequest().withBody("我说中国话", Charsets.UTF_16)));
+        assertTrue(new HttpRequestMatcher(new HttpRequest().withBody(new StringBody("我说中国话", StandardCharsets.UTF_16)), mockServerLogger).matches(null, new HttpRequest().withBody("我说中国话", StandardCharsets.UTF_16)));
     }
 
     @Test
@@ -706,12 +707,12 @@ public class HttpRequestMatcherTest {
         assertTrue(
             new HttpRequestMatcher(
                 new HttpRequest()
-                    .withBody(json("{ \"some_field\": \"我说中国话\" }", Charsets.UTF_16, MatchType.ONLY_MATCHING_FIELDS)),
+                    .withBody(json("{ \"some_field\": \"我说中国话\" }", StandardCharsets.UTF_16, MatchType.ONLY_MATCHING_FIELDS)),
                 mockServerLogger
             )
                 .matches(
                     null, new HttpRequest()
-                        .withBody(matched, Charsets.UTF_16)
+                        .withBody(matched, StandardCharsets.UTF_16)
                         .withMethod("PUT")
                 )
         );

--- a/mockserver-core/src/test/java/org/mockserver/model/BinaryBodyTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/model/BinaryBodyTest.java
@@ -1,13 +1,14 @@
 package org.mockserver.model;
 
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import org.junit.Test;
 import org.mockserver.client.serialization.Base64Converter;
 
+import java.nio.charset.StandardCharsets;
+
 import javax.xml.bind.DatatypeConverter;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
@@ -47,7 +48,7 @@ public class BinaryBodyTest {
         assertThat(binaryBody.getValue(), is(body));
         assertThat(binaryBody.getType(), is(Body.Type.BINARY));
         assertThat(binaryBody.getCharset(null), nullValue());
-        assertThat(binaryBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_8));
+        assertThat(binaryBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_8));
         assertThat(binaryBody.getContentType(), nullValue());
     }
 
@@ -63,7 +64,7 @@ public class BinaryBodyTest {
         assertThat(binaryBody.getValue(), is(body));
         assertThat(binaryBody.getType(), is(Body.Type.BINARY));
         assertThat(binaryBody.getCharset(null), nullValue());
-        assertThat(binaryBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_8));
+        assertThat(binaryBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_8));
         assertThat(binaryBody.getContentType(), nullValue());
     }
 
@@ -78,8 +79,8 @@ public class BinaryBodyTest {
         // then
         assertThat(binaryBody.getValue(), is(body));
         assertThat(binaryBody.getType(), is(Body.Type.BINARY));
-        assertThat(binaryBody.getCharset(null), is(Charsets.UTF_8));
-        assertThat(binaryBody.getCharset(Charsets.UTF_16), is(Charsets.UTF_8));
+        assertThat(binaryBody.getCharset(null), is(StandardCharsets.UTF_8));
+        assertThat(binaryBody.getCharset(StandardCharsets.UTF_16), is(StandardCharsets.UTF_8));
         assertThat(binaryBody.getContentType(), is(MediaType.PLAIN_TEXT_UTF_8.toString()));
     }
 
@@ -95,7 +96,7 @@ public class BinaryBodyTest {
         assertThat(binaryBody.getValue(), is(body));
         assertThat(binaryBody.getType(), is(Body.Type.BINARY));
         assertThat(binaryBody.getCharset(null), nullValue());
-        assertThat(binaryBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_8));
+        assertThat(binaryBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_8));
         assertThat(binaryBody.getContentType(), nullValue());
     }
 

--- a/mockserver-core/src/test/java/org/mockserver/model/HttpErrorTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/model/HttpErrorTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.*;
 import static org.mockserver.character.Character.NEW_LINE;
 import static org.mockserver.model.HttpError.error;

--- a/mockserver-core/src/test/java/org/mockserver/model/HttpResponseTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/model/HttpResponseTest.java
@@ -6,7 +6,7 @@ import org.mockserver.client.serialization.Base64Converter;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static junit.framework.TestCase.*;
 import static org.hamcrest.CoreMatchers.not;

--- a/mockserver-core/src/test/java/org/mockserver/model/JsonBodyTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/model/JsonBodyTest.java
@@ -1,9 +1,10 @@
 package org.mockserver.model;
 
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import org.junit.Test;
 import org.mockserver.matchers.MatchType;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -43,7 +44,7 @@ public class JsonBodyTest {
     @Test
     public void shouldReturnValuesSetInConstructorWithMatchTypeAndCharset() {
         // when
-        JsonBody jsonBody = new JsonBody("some_body", Charsets.UTF_16, MatchType.STRICT);
+        JsonBody jsonBody = new JsonBody("some_body", StandardCharsets.UTF_16, MatchType.STRICT);
 
         // then
         assertThat(jsonBody.getValue(), is("some_body"));
@@ -92,7 +93,7 @@ public class JsonBodyTest {
     @Test
     public void shouldReturnValuesFromStaticBuilderWithCharsetAndMatchType() {
         // when
-        JsonBody jsonBody = json("some_body", Charsets.UTF_16, STRICT);
+        JsonBody jsonBody = json("some_body", StandardCharsets.UTF_16, STRICT);
 
         // then
         assertThat(jsonBody.getValue(), is("some_body"));
@@ -116,7 +117,7 @@ public class JsonBodyTest {
     @Test
     public void shouldReturnValuesFromStaticBuilderWithMatchTypeAndCharset() {
         // when
-        JsonBody jsonBody = json("some_body", Charsets.UTF_16, STRICT);
+        JsonBody jsonBody = json("some_body", StandardCharsets.UTF_16, STRICT);
 
         // then
         assertThat(jsonBody.getValue(), is("some_body"));
@@ -152,7 +153,7 @@ public class JsonBodyTest {
     @Test
     public void shouldReturnValuesFromStaticObjectBuilderWithCharsetAndMatchType() {
         // when
-        JsonBody jsonBody = json(new TestObject(), Charsets.UTF_16, STRICT);
+        JsonBody jsonBody = json(new TestObject(), StandardCharsets.UTF_16, STRICT);
 
         // then
         assertThat(jsonBody.getValue(), is("{\"fieldOne\":\"valueOne\",\"fieldTwo\":\"valueTwo\"}"));
@@ -176,7 +177,7 @@ public class JsonBodyTest {
     @Test
     public void shouldReturnValuesFromStaticObjectBuilderWithMatchTypeAndCharset() {
         // when
-        JsonBody jsonBody = json(new TestObject(), Charsets.UTF_16, STRICT);
+        JsonBody jsonBody = json(new TestObject(), StandardCharsets.UTF_16, STRICT);
 
         // then
         assertThat(jsonBody.getValue(), is("{\"fieldOne\":\"valueOne\",\"fieldTwo\":\"valueTwo\"}"));

--- a/mockserver-core/src/test/java/org/mockserver/model/RegexBodyTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/model/RegexBodyTest.java
@@ -1,7 +1,8 @@
 package org.mockserver.model;
 
-import com.google.common.base.Charsets;
 import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
@@ -22,7 +23,7 @@ public class RegexBodyTest {
         assertThat(regexBody.getValue(), is("some_body"));
         assertThat(regexBody.getType(), is(Body.Type.REGEX));
         assertThat(regexBody.getContentType(), nullValue());
-        assertThat(regexBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_8));
+        assertThat(regexBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -34,7 +35,7 @@ public class RegexBodyTest {
         assertThat(regexBody.getValue(), is("some_body"));
         assertThat(regexBody.getType(), is(Body.Type.REGEX));
         assertThat(regexBody.getContentType(), nullValue());
-        assertThat(regexBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_8));
+        assertThat(regexBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_8));
     }
 
 }

--- a/mockserver-core/src/test/java/org/mockserver/model/StringBodyTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/model/StringBodyTest.java
@@ -1,11 +1,11 @@
 package org.mockserver.model;
 
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import org.junit.Test;
 import org.mockserver.client.serialization.model.StringBodyDTO;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
@@ -36,7 +36,7 @@ public class StringBodyTest {
         assertThat(stringBody.getValue(), is("some_body"));
         assertThat(stringBody.getType(), is(Body.Type.STRING));
         assertThat(stringBody.getCharset(null), nullValue());
-        assertThat(stringBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_8));
+        assertThat(stringBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_8));
         assertThat(stringBody.getContentType(), nullValue());
     }
 
@@ -55,14 +55,14 @@ public class StringBodyTest {
     @Test
     public void shouldReturnValuesSetInConstructorWithCharset() {
         // when
-        StringBody stringBody = new StringBody("some_body", Charsets.UTF_16);
+        StringBody stringBody = new StringBody("some_body", StandardCharsets.UTF_16);
 
         // then
         assertThat(stringBody.getValue(), is("some_body"));
         assertThat(stringBody.getType(), is(Body.Type.STRING));
-        assertThat(stringBody.getCharset(null), is(Charsets.UTF_16));
-        assertThat(stringBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_16));
-        assertThat(stringBody.getContentType(), is(MediaType.create("text", "plain").withCharset(Charsets.UTF_16).toString()));
+        assertThat(stringBody.getCharset(null), is(StandardCharsets.UTF_16));
+        assertThat(stringBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_16));
+        assertThat(stringBody.getContentType(), is(MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_16).toString()));
     }
 
     @Test
@@ -75,22 +75,22 @@ public class StringBodyTest {
         assertThat(stringBody.isSubString(), is(false));
         assertThat(stringBody.getType(), is(Body.Type.STRING));
         assertThat(stringBody.getCharset(null), nullValue());
-        assertThat(stringBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_8));
+        assertThat(stringBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_8));
         assertThat(stringBody.getContentType(), nullValue());
     }
 
     @Test
     public void shouldReturnValueSetInStaticExactConstructorWithCharset() {
         // when
-        StringBody stringBody = exact("some_body", Charsets.UTF_16);
+        StringBody stringBody = exact("some_body", StandardCharsets.UTF_16);
 
         // then
         assertThat(stringBody.getValue(), is("some_body"));
         assertThat(stringBody.isSubString(), is(false));
         assertThat(stringBody.getType(), is(Body.Type.STRING));
-        assertThat(stringBody.getCharset(null), is(Charsets.UTF_16));
-        assertThat(stringBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_16));
-        assertThat(stringBody.getContentType(), is(MediaType.create("text", "plain").withCharset(Charsets.UTF_16).toString()));
+        assertThat(stringBody.getCharset(null), is(StandardCharsets.UTF_16));
+        assertThat(stringBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_16));
+        assertThat(stringBody.getContentType(), is(MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_16).toString()));
     }
 
     @Test
@@ -103,7 +103,7 @@ public class StringBodyTest {
         assertThat(stringBody.isSubString(), is(false));
         assertThat(stringBody.getType(), is(Body.Type.STRING));
         assertThat(stringBody.getCharset(null), nullValue());
-        assertThat(stringBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_8));
+        assertThat(stringBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_8));
         assertThat(stringBody.getContentType(), nullValue());
     }
 
@@ -116,8 +116,8 @@ public class StringBodyTest {
         assertThat(stringBody.getValue(), is("some_body"));
         assertThat(stringBody.isSubString(), is(false));
         assertThat(stringBody.getType(), is(Body.Type.STRING));
-        assertThat(stringBody.getCharset(null), is(Charsets.UTF_8));
-        assertThat(stringBody.getCharset(Charsets.UTF_16), is(Charsets.UTF_8));
+        assertThat(stringBody.getCharset(null), is(StandardCharsets.UTF_8));
+        assertThat(stringBody.getCharset(StandardCharsets.UTF_16), is(StandardCharsets.UTF_8));
         assertThat(stringBody.getContentType(), is(MediaType.PLAIN_TEXT_UTF_8.toString()));
     }
 
@@ -131,7 +131,7 @@ public class StringBodyTest {
         assertThat(stringBody.isSubString(), is(false));
         assertThat(stringBody.getType(), is(Body.Type.STRING));
         assertThat(stringBody.getCharset(null), nullValue());
-        assertThat(stringBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_8));
+        assertThat(stringBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_8));
         assertThat(stringBody.getContentType(), nullValue());
     }
 
@@ -145,22 +145,22 @@ public class StringBodyTest {
         assertThat(stringBody.isSubString(), is(true));
         assertThat(stringBody.getType(), is(Body.Type.STRING));
         assertThat(stringBody.getCharset(null), nullValue());
-        assertThat(stringBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_8));
+        assertThat(stringBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_8));
         assertThat(stringBody.getContentType(), nullValue());
     }
 
     @Test
     public void shouldReturnValueSetInStaticSubStringConstructorWithCharset() {
         // when
-        StringBody stringBody = subString("some_body", Charsets.UTF_16);
+        StringBody stringBody = subString("some_body", StandardCharsets.UTF_16);
 
         // then
         assertThat(stringBody.getValue(), is("some_body"));
         assertThat(stringBody.isSubString(), is(true));
         assertThat(stringBody.getType(), is(Body.Type.STRING));
-        assertThat(stringBody.getCharset(null), is(Charsets.UTF_16));
-        assertThat(stringBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_16));
-        assertThat(stringBody.getContentType(), is(MediaType.create("text", "plain").withCharset(Charsets.UTF_16).toString()));
+        assertThat(stringBody.getCharset(null), is(StandardCharsets.UTF_16));
+        assertThat(stringBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_16));
+        assertThat(stringBody.getContentType(), is(MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_16).toString()));
     }
 
     @Test
@@ -173,7 +173,7 @@ public class StringBodyTest {
         assertThat(stringBody.isSubString(), is(true));
         assertThat(stringBody.getType(), is(Body.Type.STRING));
         assertThat(stringBody.getCharset(null), nullValue());
-        assertThat(stringBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_8));
+        assertThat(stringBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_8));
         assertThat(stringBody.getContentType(), nullValue());
     }
 
@@ -186,8 +186,8 @@ public class StringBodyTest {
         assertThat(stringBody.getValue(), is("some_body"));
         assertThat(stringBody.isSubString(), is(true));
         assertThat(stringBody.getType(), is(Body.Type.STRING));
-        assertThat(stringBody.getCharset(null), is(Charsets.UTF_8));
-        assertThat(stringBody.getCharset(Charsets.UTF_16), is(Charsets.UTF_8));
+        assertThat(stringBody.getCharset(null), is(StandardCharsets.UTF_8));
+        assertThat(stringBody.getCharset(StandardCharsets.UTF_16), is(StandardCharsets.UTF_8));
         assertThat(stringBody.getContentType(), is(MediaType.PLAIN_TEXT_UTF_8.toString()));
     }
 
@@ -201,7 +201,7 @@ public class StringBodyTest {
         assertThat(stringBody.isSubString(), is(true));
         assertThat(stringBody.getType(), is(Body.Type.STRING));
         assertThat(stringBody.getCharset(null), nullValue());
-        assertThat(stringBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_8));
+        assertThat(stringBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_8));
         assertThat(stringBody.getContentType(), nullValue());
     }
 

--- a/mockserver-core/src/test/java/org/mockserver/model/XmlBodyTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/model/XmlBodyTest.java
@@ -1,10 +1,10 @@
 package org.mockserver.model;
 
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import org.junit.Test;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
@@ -33,21 +33,21 @@ public class XmlBodyTest {
         assertThat(xmlBody.getValue(), is("some_body"));
         assertThat(xmlBody.getType(), is(Body.Type.XML));
         assertThat(xmlBody.getContentType(), is(XmlBody.DEFAULT_CONTENT_TYPE.toString()));
-        assertThat(xmlBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_8));
+        assertThat(xmlBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_8));
         assertThat(xmlBody.getContentType(), is(MediaType.create("application", "xml").toString()));
     }
 
     @Test
     public void shouldReturnValuesSetInConstructorWithCharset() {
         // when
-        XmlBody xmlBody = new XmlBody("some_body", Charsets.UTF_16);
+        XmlBody xmlBody = new XmlBody("some_body", StandardCharsets.UTF_16);
 
         // then
         assertThat(xmlBody.getValue(), is("some_body"));
         assertThat(xmlBody.getType(), is(Body.Type.XML));
-        assertThat(xmlBody.getCharset(null), is(Charsets.UTF_16));
-        assertThat(xmlBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_16));
-        assertThat(xmlBody.getContentType(), is(MediaType.APPLICATION_XML_UTF_8.withCharset(Charsets.UTF_16).toString()));
+        assertThat(xmlBody.getCharset(null), is(StandardCharsets.UTF_16));
+        assertThat(xmlBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_16));
+        assertThat(xmlBody.getContentType(), is(MediaType.APPLICATION_XML_UTF_8.withCharset(StandardCharsets.UTF_16).toString()));
     }
 
     @Test
@@ -59,21 +59,21 @@ public class XmlBodyTest {
         assertThat(xmlBody.getValue(), is("some_body"));
         assertThat(xmlBody.getType(), is(Body.Type.XML));
         assertThat(xmlBody.getContentType(), is(XmlBody.DEFAULT_CONTENT_TYPE.toString()));
-        assertThat(xmlBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_8));
+        assertThat(xmlBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_8));
         assertThat(xmlBody.getContentType(), is(MediaType.create("application", "xml").toString()));
     }
 
     @Test
     public void shouldReturnValueSetInStaticConstructorWithCharset() {
         // when
-        XmlBody xmlBody = xml("some_body", Charsets.UTF_16);
+        XmlBody xmlBody = xml("some_body", StandardCharsets.UTF_16);
 
         // then
         assertThat(xmlBody.getValue(), is("some_body"));
         assertThat(xmlBody.getType(), is(Body.Type.XML));
-        assertThat(xmlBody.getCharset(null), is(Charsets.UTF_16));
-        assertThat(xmlBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_16));
-        assertThat(xmlBody.getContentType(), is(MediaType.APPLICATION_XML_UTF_8.withCharset(Charsets.UTF_16).toString()));
+        assertThat(xmlBody.getCharset(null), is(StandardCharsets.UTF_16));
+        assertThat(xmlBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_16));
+        assertThat(xmlBody.getContentType(), is(MediaType.APPLICATION_XML_UTF_8.withCharset(StandardCharsets.UTF_16).toString()));
     }
 
     @Test
@@ -85,7 +85,7 @@ public class XmlBodyTest {
         assertThat(xmlBody.getValue(), is("some_body"));
         assertThat(xmlBody.getType(), is(Body.Type.XML));
         assertThat(xmlBody.getCharset(null), nullValue());
-        assertThat(xmlBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_8));
+        assertThat(xmlBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_8));
         assertThat(xmlBody.getContentType(), nullValue());
     }
 
@@ -97,8 +97,8 @@ public class XmlBodyTest {
         // then
         assertThat(xmlBody.getValue(), is("some_body"));
         assertThat(xmlBody.getType(), is(Body.Type.XML));
-        assertThat(xmlBody.getCharset(null), is(Charsets.UTF_8));
-        assertThat(xmlBody.getCharset(Charsets.UTF_16), is(Charsets.UTF_8));
+        assertThat(xmlBody.getCharset(null), is(StandardCharsets.UTF_8));
+        assertThat(xmlBody.getCharset(StandardCharsets.UTF_16), is(StandardCharsets.UTF_8));
         assertThat(xmlBody.getContentType(), is(MediaType.PLAIN_TEXT_UTF_8.toString()));
     }
 
@@ -111,7 +111,7 @@ public class XmlBodyTest {
         assertThat(xmlBody.getValue(), is("some_body"));
         assertThat(xmlBody.getType(), is(Body.Type.XML));
         assertThat(xmlBody.getCharset(null), nullValue());
-        assertThat(xmlBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_8));
+        assertThat(xmlBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_8));
         assertThat(xmlBody.getContentType(), nullValue());
     }
 

--- a/mockserver-core/src/test/java/org/mockserver/model/XpathBodyTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/model/XpathBodyTest.java
@@ -1,7 +1,8 @@
 package org.mockserver.model;
 
-import com.google.common.base.Charsets;
 import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
@@ -22,7 +23,7 @@ public class XpathBodyTest {
         assertThat(xPathBody.getValue(), is("some_body"));
         assertThat(xPathBody.getType(), is(Body.Type.XPATH));
         assertThat(xPathBody.getContentType(), nullValue());
-        assertThat(xPathBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_8));
+        assertThat(xPathBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -34,7 +35,7 @@ public class XpathBodyTest {
         assertThat(xPathBody.getValue(), is("some_body"));
         assertThat(xPathBody.getType(), is(Body.Type.XPATH));
         assertThat(xPathBody.getContentType(), nullValue());
-        assertThat(xPathBody.getCharset(Charsets.UTF_8), is(Charsets.UTF_8));
+        assertThat(xPathBody.getCharset(StandardCharsets.UTF_8), is(StandardCharsets.UTF_8));
     }
 
 }

--- a/mockserver-core/src/test/java/org/mockserver/server/netty/codec/MockServerRequestDecoderTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/server/netty/codec/MockServerRequestDecoderTest.java
@@ -1,6 +1,5 @@
 package org.mockserver.server.netty.codec;
 
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.*;
@@ -14,10 +13,11 @@ import org.mockserver.model.*;
 import org.mockserver.model.Cookie;
 import org.mockserver.model.HttpRequest;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -173,10 +173,10 @@ public class MockServerRequestDecoderTest {
         ));
     }
 
-    /* 
+    /*
      * Test is significant because popular Java REST library Jersey adds $Version=1 to all cookies
-     * in line with RFC2965's recommendation (even though RFC2965 is now marked "Obsolete" by 
-     * RFC6265, this is still common and not hard to handle). 
+     * in line with RFC2965's recommendation (even though RFC2965 is now marked "Obsolete" by
+     * RFC6265, this is still common and not hard to handle).
      */
     @Test
     public void shouldDecodeCookiesWithRFC2965StyleAttributes() {
@@ -193,7 +193,7 @@ public class MockServerRequestDecoderTest {
                 cookie("Customer", "WILE_E_COYOTE")
         ));
     }
-    
+
     @Test
     public void shouldDecodeBodyWithContentTypeAndNoCharset() {
         // given
@@ -253,7 +253,7 @@ public class MockServerRequestDecoderTest {
     @Test
     public void shouldDecodeBodyWithUTF8ContentType() {
         // given
-        fullHttpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri", Unpooled.wrappedBuffer("avro işarəsi: \u20AC".getBytes(Charsets.UTF_8)));
+        fullHttpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri", Unpooled.wrappedBuffer("avro işarəsi: \u20AC".getBytes(StandardCharsets.UTF_8)));
         fullHttpRequest.headers().add(CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8.toString());
 
         // when
@@ -261,21 +261,21 @@ public class MockServerRequestDecoderTest {
 
         // then
         Body body = ((HttpRequest) output.get(0)).getBody();
-        assertThat(body, Is.<Body>is(exact("avro işarəsi: \u20AC", Charsets.UTF_8)));
+        assertThat(body, Is.<Body>is(exact("avro işarəsi: \u20AC", StandardCharsets.UTF_8)));
     }
 
     @Test
     public void shouldDecodeBodyWithUTF16ContentType() {
         // given
-        fullHttpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri", Unpooled.wrappedBuffer("我说中国话".getBytes(Charsets.UTF_16)));
-        fullHttpRequest.headers().add(CONTENT_TYPE, MediaType.create("text", "plain").withCharset(Charsets.UTF_16).toString());
+        fullHttpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/uri", Unpooled.wrappedBuffer("我说中国话".getBytes(StandardCharsets.UTF_16)));
+        fullHttpRequest.headers().add(CONTENT_TYPE, MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_16).toString());
 
         // when
         mockServerRequestDecoder.decode(null, fullHttpRequest, output);
 
         // then
         Body body = ((HttpRequest) output.get(0)).getBody();
-        assertThat(body, Is.<Body>is(exact("我说中国话", Charsets.UTF_16)));
+        assertThat(body, Is.<Body>is(exact("我说中国话", StandardCharsets.UTF_16)));
     }
 
     @Test

--- a/mockserver-core/src/test/java/org/mockserver/server/netty/codec/MockServerResponseEncoderBasicMappingTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/server/netty/codec/MockServerResponseEncoderBasicMappingTest.java
@@ -11,7 +11,7 @@ import org.mockserver.server.netty.codec.MockServerResponseEncoder;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;

--- a/mockserver-core/src/test/java/org/mockserver/server/netty/codec/MockServerResponseEncoderContentLengthTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/server/netty/codec/MockServerResponseEncoderContentLengthTest.java
@@ -11,7 +11,7 @@ import org.mockserver.server.netty.codec.MockServerResponseEncoder;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;

--- a/mockserver-core/src/test/java/org/mockserver/server/netty/codec/MockServerResponseEncoderContentTypeTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/server/netty/codec/MockServerResponseEncoderContentTypeTest.java
@@ -1,6 +1,5 @@
 package org.mockserver.server.netty.codec;
 
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.util.CharsetUtil;
@@ -11,10 +10,11 @@ import org.mockserver.model.Header;
 import org.mockserver.model.HttpResponse;
 import org.mockserver.server.netty.codec.MockServerResponseEncoder;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
@@ -102,43 +102,43 @@ public class MockServerResponseEncoderContentTypeTest {
     @Test
     public void shouldDecodeBodyWithUTF8ContentType() {
         // given
-        httpResponse.withBody("avro işarəsi: \u20AC", Charsets.UTF_8);
-        httpResponse.withHeader(new Header(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(Charsets.UTF_8).toString()));
+        httpResponse.withBody("avro işarəsi: \u20AC", StandardCharsets.UTF_8);
+        httpResponse.withHeader(new Header(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_8).toString()));
 
         // when
         new MockServerResponseEncoder().encode(null, httpResponse, output);
 
         // then
         FullHttpResponse fullHttpResponse = (FullHttpResponse) output.get(0);
-        assertThat(new String(fullHttpResponse.content().array(), Charsets.UTF_8), is("avro işarəsi: \u20AC"));
+        assertThat(new String(fullHttpResponse.content().array(), StandardCharsets.UTF_8), is("avro işarəsi: \u20AC"));
     }
 
     @Test
     public void shouldDecodeBodyWithUTF16ContentType() {
         // given
-        httpResponse.withBody("我说中国话", Charsets.UTF_16);
-        httpResponse.withHeader(new Header(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(Charsets.UTF_16).toString()));
+        httpResponse.withBody("我说中国话", StandardCharsets.UTF_16);
+        httpResponse.withHeader(new Header(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_16).toString()));
 
         // when
         new MockServerResponseEncoder().encode(null, httpResponse, output);
 
         // then
         FullHttpResponse fullHttpResponse = (FullHttpResponse) output.get(0);
-        assertThat(new String(fullHttpResponse.content().array(), Charsets.UTF_16), is("我说中国话"));
+        assertThat(new String(fullHttpResponse.content().array(), StandardCharsets.UTF_16), is("我说中国话"));
     }
 
     @Test
     public void shouldEncodeStringBodyWithCharset() {
         // given
-        httpResponse.withBody("我说中国话", Charsets.UTF_16);
+        httpResponse.withBody("我说中国话", StandardCharsets.UTF_16);
 
         // when
         new MockServerResponseEncoder().encode(null, httpResponse, output);
 
         // then
         FullHttpResponse fullHttpRequest = (FullHttpResponse) output.get(0);
-        assertThat(new String(fullHttpRequest.content().array(), Charsets.UTF_16), is("我说中国话"));
-        assertThat(fullHttpRequest.headers().get(CONTENT_TYPE), is(MediaType.create("text", "plain").withCharset(Charsets.UTF_16).toString()));
+        assertThat(new String(fullHttpRequest.content().array(), StandardCharsets.UTF_16), is("我说中国话"));
+        assertThat(fullHttpRequest.headers().get(CONTENT_TYPE), is(MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_16).toString()));
     }
 
     @Test
@@ -151,36 +151,36 @@ public class MockServerResponseEncoderContentTypeTest {
 
         // then
         FullHttpResponse fullHttpResponse = (FullHttpResponse) output.get(0);
-        assertThat(new String(fullHttpResponse.content().array(), Charsets.UTF_8), is("{ \"some_field\": \"我说中国话\" }"));
+        assertThat(new String(fullHttpResponse.content().array(), StandardCharsets.UTF_8), is("{ \"some_field\": \"我说中国话\" }"));
         assertThat(fullHttpResponse.headers().get(CONTENT_TYPE), is(MediaType.JSON_UTF_8.toString()));
     }
 
     @Test
     public void shouldEncodeUTF8JsonBodyWithCharset() {
         // given
-        httpResponse.withBody(json("{ \"some_field\": \"我说中国话\" }", Charsets.UTF_8));
+        httpResponse.withBody(json("{ \"some_field\": \"我说中国话\" }", StandardCharsets.UTF_8));
 
         // when
         new MockServerResponseEncoder().encode(null, httpResponse, output);
 
         // then
         FullHttpResponse fullHttpResponse = (FullHttpResponse) output.get(0);
-        assertThat(new String(fullHttpResponse.content().array(), Charsets.UTF_8), is("{ \"some_field\": \"我说中国话\" }"));
+        assertThat(new String(fullHttpResponse.content().array(), StandardCharsets.UTF_8), is("{ \"some_field\": \"我说中国话\" }"));
         assertThat(fullHttpResponse.headers().get(CONTENT_TYPE), is(MediaType.JSON_UTF_8.toString()));
     }
 
     @Test
     public void shouldPreferStringBodyCharacterSet() {
         // given
-        httpResponse.withBody("avro işarəsi: \u20AC", Charsets.UTF_16);
-        httpResponse.withHeader(new Header(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(Charsets.US_ASCII).toString()));
+        httpResponse.withBody("avro işarəsi: \u20AC", StandardCharsets.UTF_16);
+        httpResponse.withHeader(new Header(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(StandardCharsets.US_ASCII).toString()));
 
         // when
         new MockServerResponseEncoder().encode(null, httpResponse, output);
 
         // then
         FullHttpResponse fullHttpResponse = (FullHttpResponse) output.get(0);
-        assertThat(new String(fullHttpResponse.content().array(), Charsets.UTF_16), is("avro işarəsi: \u20AC"));
+        assertThat(new String(fullHttpResponse.content().array(), StandardCharsets.UTF_16), is("avro işarəsi: \u20AC"));
     }
 
     @Test
@@ -222,7 +222,7 @@ public class MockServerResponseEncoderContentTypeTest {
     @Test
     public void shouldReturnContentTypeForStringBodyWithCharset() {
         // given - a request & response
-        httpResponse.withBody(exact("somebody", Charsets.UTF_16));
+        httpResponse.withBody(exact("somebody", StandardCharsets.UTF_16));
 
         // when
         new MockServerResponseEncoder().encode(null, httpResponse, output);

--- a/mockserver-core/src/test/java/org/mockserver/streams/IOStreamUtilsTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/streams/IOStreamUtilsTest.java
@@ -1,6 +1,5 @@
 package org.mockserver.streams;
 
-import com.google.common.base.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 

--- a/mockserver-core/src/test/java/org/mockserver/validator/jsonschema/JsonSchemaHttpRequestValidatorIntegrationTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/validator/jsonschema/JsonSchemaHttpRequestValidatorIntegrationTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 import org.mockserver.client.serialization.HttpRequestSerializer;
 import org.mockserver.logging.MockServerLogger;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockserver.character.Character.NEW_LINE;

--- a/mockserver-examples/src/main/java/org/mockserver/examples/mockserver/CallbackActionExamples.java
+++ b/mockserver-examples/src/main/java/org/mockserver/examples/mockserver/CallbackActionExamples.java
@@ -7,7 +7,7 @@ import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 import org.mockserver.model.HttpStatusCode;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.mockserver.model.Header.header;
 import static org.mockserver.model.HttpClassCallback.callback;
 import static org.mockserver.model.HttpRequest.request;

--- a/mockserver-examples/src/main/java/org/mockserver/examples/mockserver/RequestMatcherExamples.java
+++ b/mockserver-examples/src/main/java/org/mockserver/examples/mockserver/RequestMatcherExamples.java
@@ -1,6 +1,5 @@
 package org.mockserver.examples.mockserver;
 
-import com.google.common.base.Charsets;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.matchers.MatchType;
 import org.mockserver.matchers.TimeToLive;
@@ -8,6 +7,7 @@ import org.mockserver.matchers.Times;
 import org.mockserver.model.HttpStatusCode;
 import org.mockserver.model.Not;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockserver.model.Cookie.cookie;
@@ -282,7 +282,7 @@ public class RequestMatcherExamples {
         new MockServerClient("localhost", 1080)
             .when(
                 request()
-                    .withBody(exact("我说中国话", Charsets.UTF_16))
+                    .withBody(exact("我说中国话", StandardCharsets.UTF_16))
             )
             .respond(
                 response()

--- a/mockserver-examples/src/main/java/org/mockserver/examples/mockserver/ResponseActionExamples.java
+++ b/mockserver-examples/src/main/java/org/mockserver/examples/mockserver/ResponseActionExamples.java
@@ -1,6 +1,5 @@
 package org.mockserver.examples.mockserver;
 
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import org.apache.commons.io.IOUtils;
 import org.mockserver.client.MockServerClient;
@@ -9,6 +8,7 @@ import org.mockserver.model.HttpStatusCode;
 import org.mockserver.model.HttpTemplate;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_DISPOSITION;
@@ -47,9 +47,9 @@ public class ResponseActionExamples {
                 response()
                     .withHeader(
                         CONTENT_TYPE.toString(),
-                        MediaType.create("text", "plain").withCharset(Charsets.UTF_16).toString()
+                        MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_16).toString()
                     )
-                    .withBody("我说中国话".getBytes(Charsets.UTF_16))
+                    .withBody("我说中国话".getBytes(StandardCharsets.UTF_16))
             );
     }
 

--- a/mockserver-examples/src/main/java/org/mockserver/examples/proxy/service/apacheclient/BookServiceApacheHttpClient.java
+++ b/mockserver-examples/src/main/java/org/mockserver/examples/proxy/service/apacheclient/BookServiceApacheHttpClient.java
@@ -1,7 +1,6 @@
 package org.mockserver.examples.proxy.service.apacheclient;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Charsets;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -15,6 +14,8 @@ import org.mockserver.examples.proxy.model.Book;
 import org.mockserver.examples.proxy.service.BookService;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.Resource;
@@ -57,7 +58,7 @@ public class BookServiceApacheHttpClient implements BookService {
                     .setPort(port)
                     .setPath("/get_books")
                     .build()));
-            responseBody = new String(EntityUtils.toByteArray(response.getEntity()), Charsets.UTF_8);
+            responseBody = new String(EntityUtils.toByteArray(response.getEntity()), StandardCharsets.UTF_8);
         } catch (Exception e) {
             throw new RuntimeException("Exception making request to retrieve all books", e);
         }

--- a/mockserver-integration-testing/src/main/java/org/mockserver/integration/callback/PrecannedTestExpectationResponseCallback.java
+++ b/mockserver-integration-testing/src/main/java/org/mockserver/integration/callback/PrecannedTestExpectationResponseCallback.java
@@ -5,7 +5,7 @@ import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 import org.mockserver.model.HttpStatusCode;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.mockserver.model.Header.header;
 import static org.mockserver.model.HttpResponse.notFoundResponse;
 import static org.mockserver.model.HttpResponse.response;

--- a/mockserver-integration-testing/src/main/java/org/mockserver/integration/proxy/AbstractClientProxyIntegrationTest.java
+++ b/mockserver-integration-testing/src/main/java/org/mockserver/integration/proxy/AbstractClientProxyIntegrationTest.java
@@ -1,6 +1,5 @@
 package org.mockserver.integration.proxy;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
@@ -30,6 +29,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
@@ -112,7 +112,7 @@ public abstract class AbstractClientProxyIntegrationTest {
                 "x-test: test_headers_only\r" + NEW_LINE +
                 "Connection: keep-alive\r" + NEW_LINE +
                 "\r\n"
-            ).getBytes(Charsets.UTF_8));
+            ).getBytes(StandardCharsets.UTF_8));
             output.flush();
 
             // then
@@ -130,11 +130,11 @@ public abstract class AbstractClientProxyIntegrationTest {
             output.write(("" +
                 "GET " + addContextToPath("test_headers_and_body") + " HTTP/1.1\r" + NEW_LINE +
                 "Host: localhost:" + getServerPort() + "\r" + NEW_LINE +
-                "Content-Length: " + "an_example_body".getBytes(Charsets.UTF_8).length + "\r" + NEW_LINE +
+                "Content-Length: " + "an_example_body".getBytes(StandardCharsets.UTF_8).length + "\r" + NEW_LINE +
                 "x-test: test_headers_and_body\r" + NEW_LINE +
                 "\r" + NEW_LINE +
                 "an_example_body"
-            ).getBytes(Charsets.UTF_8));
+            ).getBytes(StandardCharsets.UTF_8));
             output.flush();
 
             // then
@@ -249,7 +249,7 @@ public abstract class AbstractClientProxyIntegrationTest {
                 "Host: localhost:" + getServerPort() + "\r" + NEW_LINE +
                 "Connection: close\r" + NEW_LINE +
                 "\r\n"
-            ).getBytes(Charsets.UTF_8));
+            ).getBytes(StandardCharsets.UTF_8));
             output.flush();
 
             // then

--- a/mockserver-integration-testing/src/main/java/org/mockserver/integration/proxy/AbstractClientSecureProxyIntegrationTest.java
+++ b/mockserver-integration-testing/src/main/java/org/mockserver/integration/proxy/AbstractClientSecureProxyIntegrationTest.java
@@ -1,6 +1,5 @@
 package org.mockserver.integration.proxy;
 
-import com.google.common.base.Charsets;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -21,6 +20,7 @@ import org.mockserver.streams.IOStreamUtils;
 import javax.net.ssl.SSLSocket;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockserver.model.HttpRequest.request;
@@ -52,7 +52,7 @@ public abstract class AbstractClientSecureProxyIntegrationTest {
                     "CONNECT localhost:443 HTTP/1.1\r\n" +
                     "Host: localhost:" + getServerSecurePort() + "\r\n" +
                     "\r\n"
-            ).getBytes(Charsets.UTF_8));
+            ).getBytes(StandardCharsets.UTF_8));
             output.flush();
 
             // then
@@ -78,7 +78,7 @@ public abstract class AbstractClientSecureProxyIntegrationTest {
                     "CONNECT localhost:443 HTTP/1.1\r\n" +
                     "Host: localhost:" + getServerSecurePort() + "\r\n" +
                     "\r\n"
-            ).getBytes(Charsets.UTF_8));
+            ).getBytes(StandardCharsets.UTF_8));
             output.flush();
 
             // - flush CONNECT response
@@ -98,7 +98,7 @@ public abstract class AbstractClientSecureProxyIntegrationTest {
                         "X-Test: test_headers_only\r\n" +
                         "Connection: keep-alive\r\n" +
                         "\r\n"
-                ).getBytes(Charsets.UTF_8));
+                ).getBytes(StandardCharsets.UTF_8));
                 output.flush();
 
                 // then
@@ -108,11 +108,11 @@ public abstract class AbstractClientSecureProxyIntegrationTest {
                 output.write(("" +
                         "GET /test_headers_and_body HTTP/1.1\r\n" +
                         "Host: localhost:" + getServerSecurePort() + "\r\n" +
-                        "Content-Length: " + "an_example_body".getBytes(Charsets.UTF_8).length + "\r\n" +
+                        "Content-Length: " + "an_example_body".getBytes(StandardCharsets.UTF_8).length + "\r\n" +
                         "X-Test: test_headers_and_body\r\n" +
                         "\r\n" +
                         "an_example_body"
-                ).getBytes(Charsets.UTF_8));
+                ).getBytes(StandardCharsets.UTF_8));
                 output.flush();
 
                 // then
@@ -169,7 +169,7 @@ public abstract class AbstractClientSecureProxyIntegrationTest {
 
         // then
         assertEquals(HttpStatusCode.OK_200.code(), response.getStatusLine().getStatusCode());
-        assertEquals("an_example_body", new String(EntityUtils.toByteArray(response.getEntity()), com.google.common.base.Charsets.UTF_8));
+        assertEquals("an_example_body", new String(EntityUtils.toByteArray(response.getEntity()), StandardCharsets.UTF_8));
 
         // and
         getProxyClient().verify(
@@ -194,7 +194,7 @@ public abstract class AbstractClientSecureProxyIntegrationTest {
                     "CONNECT localhost:443 HTTP/1.1\r\n" +
                     "Host: localhost:" + getServerSecurePort() + "\r\n" +
                     "\r\n"
-            ).getBytes(Charsets.UTF_8));
+            ).getBytes(StandardCharsets.UTF_8));
             output.flush();
 
             // - flush CONNECT response
@@ -211,7 +211,7 @@ public abstract class AbstractClientSecureProxyIntegrationTest {
                         "GET /not_found HTTP/1.1\r\n" +
                         "Host: localhost:" + getServerSecurePort() + "\r\n" +
                         "\r\n"
-                ).getBytes(Charsets.UTF_8));
+                ).getBytes(StandardCharsets.UTF_8));
                 output.flush();
 
                 // then

--- a/mockserver-integration-testing/src/main/java/org/mockserver/integration/server/AbstractExtendedMockingIntegrationTest.java
+++ b/mockserver-integration-testing/src/main/java/org/mockserver/integration/server/AbstractExtendedMockingIntegrationTest.java
@@ -1,6 +1,5 @@
 package org.mockserver.integration.server;
 
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.commons.io.IOUtils;
@@ -17,6 +16,7 @@ import org.mockserver.model.*;
 import org.mockserver.verify.VerificationTimes;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.*;
@@ -312,26 +312,26 @@ public abstract class AbstractExtendedMockingIntegrationTest extends AbstractBas
     public void shouldReturnMatchRequestWithBodyInUTF16() {
         // when
         String body = "我说中国话";
-        mockServerClient.when(request().withBody(body, Charsets.UTF_16)).respond(response().withBody(body, Charsets.UTF_8));
+        mockServerClient.when(request().withBody(body, StandardCharsets.UTF_16)).respond(response().withBody(body, StandardCharsets.UTF_8));
 
         // then
         // - in http
         assertEquals(
             response()
-                .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(Charsets.UTF_8).toString())
+                .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_8).toString())
                 .withStatusCode(OK_200.code())
                 .withReasonPhrase(OK_200.reasonPhrase())
                 .withBody(body),
             makeRequest(
                 request()
                     .withPath(calculatePath(""))
-                    .withBody(body, Charsets.UTF_16),
+                    .withBody(body, StandardCharsets.UTF_16),
                 headersToIgnore)
         );
         // - in https
         assertEquals(
             response()
-                .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(Charsets.UTF_8).toString())
+                .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_8).toString())
                 .withStatusCode(OK_200.code())
                 .withReasonPhrase(OK_200.reasonPhrase())
                 .withBody(body),
@@ -339,7 +339,7 @@ public abstract class AbstractExtendedMockingIntegrationTest extends AbstractBas
                 request()
                     .withSecure(true)
                     .withPath(calculatePath(""))
-                    .withBody(body, Charsets.UTF_16),
+                    .withBody(body, StandardCharsets.UTF_16),
                 headersToIgnore)
         );
     }
@@ -351,25 +351,25 @@ public abstract class AbstractExtendedMockingIntegrationTest extends AbstractBas
         mockServerClient
             .when(
                 request()
-                    .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(Charsets.UTF_8).toString())
+                    .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_8).toString())
                     .withBody(body)
             )
             .respond(
                 response()
-                    .withBody(body, Charsets.UTF_8)
+                    .withBody(body, StandardCharsets.UTF_8)
             );
 
         // then
         // - in http
         assertEquals(
             response()
-                .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(Charsets.UTF_8).toString())
+                .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_8).toString())
                 .withStatusCode(OK_200.code())
                 .withReasonPhrase(OK_200.reasonPhrase())
                 .withBody(body),
             makeRequest(
                 request()
-                    .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(Charsets.UTF_8).toString())
+                    .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_8).toString())
                     .withPath(calculatePath(""))
                     .withBody(body),
                 headersToIgnore)
@@ -377,13 +377,13 @@ public abstract class AbstractExtendedMockingIntegrationTest extends AbstractBas
         // - in https
         assertEquals(
             response()
-                .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(Charsets.UTF_8).toString())
+                .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_8).toString())
                 .withStatusCode(OK_200.code())
                 .withReasonPhrase(OK_200.reasonPhrase())
                 .withBody(body),
             makeRequest(
                 request()
-                    .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(Charsets.UTF_8).toString())
+                    .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_8).toString())
                     .withSecure(true)
                     .withPath(calculatePath(""))
                     .withBody(body),
@@ -395,13 +395,13 @@ public abstract class AbstractExtendedMockingIntegrationTest extends AbstractBas
     public void shouldReturnResponseWithBodyInUTF16() {
         // when
         String body = "我说中国话";
-        mockServerClient.when(request()).respond(response().withBody(body, Charsets.UTF_16));
+        mockServerClient.when(request()).respond(response().withBody(body, StandardCharsets.UTF_16));
 
         // then
         // - in http
         assertEquals(
             response()
-                .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(Charsets.UTF_16).toString())
+                .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_16).toString())
                 .withStatusCode(OK_200.code())
                 .withReasonPhrase(OK_200.reasonPhrase())
                 .withBody(body),
@@ -413,7 +413,7 @@ public abstract class AbstractExtendedMockingIntegrationTest extends AbstractBas
         // - in https
         assertEquals(
             response()
-                .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(Charsets.UTF_16).toString())
+                .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_16).toString())
                 .withStatusCode(OK_200.code())
                 .withReasonPhrase(OK_200.reasonPhrase())
                 .withBody(body),
@@ -435,7 +435,7 @@ public abstract class AbstractExtendedMockingIntegrationTest extends AbstractBas
             )
             .respond(
                 response()
-                    .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(Charsets.UTF_8).toString())
+                    .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_8).toString())
                     .withBody(body)
             );
 
@@ -443,7 +443,7 @@ public abstract class AbstractExtendedMockingIntegrationTest extends AbstractBas
         // - in http
         assertEquals(
             response()
-                .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(Charsets.UTF_8).toString())
+                .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_8).toString())
                 .withStatusCode(OK_200.code())
                 .withReasonPhrase(OK_200.reasonPhrase())
                 .withBody(body),
@@ -455,7 +455,7 @@ public abstract class AbstractExtendedMockingIntegrationTest extends AbstractBas
         // - in https
         assertEquals(
             response()
-                .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(Charsets.UTF_8).toString())
+                .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_8).toString())
                 .withStatusCode(OK_200.code())
                 .withReasonPhrase(OK_200.reasonPhrase())
                 .withBody(body),
@@ -720,7 +720,7 @@ public abstract class AbstractExtendedMockingIntegrationTest extends AbstractBas
                         "    \"όνομα\": \"μια πράσινη πόρτα\"," + NEW_LINE +
                         "    \"τιμή\": 12.50," + NEW_LINE +
                         "    \"ετικέτες\": [\"σπίτι\", \"πράσινος\"]" + NEW_LINE +
-                        "}", Charsets.UTF_16, MatchType.ONLY_MATCHING_FIELDS)),
+                        "}", StandardCharsets.UTF_16, MatchType.ONLY_MATCHING_FIELDS)),
                 exactly(2)
             )
             .respond(
@@ -747,7 +747,7 @@ public abstract class AbstractExtendedMockingIntegrationTest extends AbstractBas
                         "    \"όνομα\": \"μια πράσινη πόρτα\"," + NEW_LINE +
                         "    \"τιμή\": 12.50," + NEW_LINE +
                         "    \"ετικέτες\": [\"σπίτι\", \"πράσινος\"]" + NEW_LINE +
-                        "}", Charsets.UTF_16, MatchType.ONLY_MATCHING_FIELDS)),
+                        "}", StandardCharsets.UTF_16, MatchType.ONLY_MATCHING_FIELDS)),
                 headersToIgnore)
         );
         // - in https
@@ -767,7 +767,7 @@ public abstract class AbstractExtendedMockingIntegrationTest extends AbstractBas
                         "    \"όνομα\": \"μια πράσινη πόρτα\"," + NEW_LINE +
                         "    \"τιμή\": 12.50," + NEW_LINE +
                         "    \"ετικέτες\": [\"σπίτι\", \"πράσινος\"]" + NEW_LINE +
-                        "}", Charsets.UTF_16, MatchType.ONLY_MATCHING_FIELDS)),
+                        "}", StandardCharsets.UTF_16, MatchType.ONLY_MATCHING_FIELDS)),
                 headersToIgnore)
         );
     }
@@ -783,7 +783,7 @@ public abstract class AbstractExtendedMockingIntegrationTest extends AbstractBas
                         "    \"όνομα\": \"μια πράσινη πόρτα\"," + NEW_LINE +
                         "    \"τιμή\": 12.50," + NEW_LINE +
                         "    \"ετικέτες\": [\"σπίτι\", \"πράσινος\"]" + NEW_LINE +
-                        "}", Charsets.UTF_16, MatchType.ONLY_MATCHING_FIELDS)),
+                        "}", StandardCharsets.UTF_16, MatchType.ONLY_MATCHING_FIELDS)),
                 exactly(2)
             )
             .respond(
@@ -802,7 +802,7 @@ public abstract class AbstractExtendedMockingIntegrationTest extends AbstractBas
                 .withBody("some_body"),
             makeRequest(
                 request()
-                    .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(Charsets.UTF_16).toString())
+                    .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_16).toString())
                     .withPath(calculatePath("some_path"))
                     .withMethod("POST")
                     .withBody(json("{" + NEW_LINE +
@@ -823,7 +823,7 @@ public abstract class AbstractExtendedMockingIntegrationTest extends AbstractBas
             makeRequest(
                 request()
                     .withSecure(true)
-                    .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(Charsets.UTF_16).toString())
+                    .withHeader(CONTENT_TYPE.toString(), MediaType.create("text", "plain").withCharset(StandardCharsets.UTF_16).toString())
                     .withPath(calculatePath("some_path"))
                     .withMethod("POST")
                     .withBody(json("{" + NEW_LINE +

--- a/mockserver-netty/src/test/java/org/mockserver/integration/mocking/AbstractExtendedNettyMockingIntegrationTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/integration/mocking/AbstractExtendedNettyMockingIntegrationTest.java
@@ -1,6 +1,5 @@
 package org.mockserver.integration.mocking;
 
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
@@ -23,12 +22,13 @@ import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static io.netty.handler.codec.http.HttpHeaderNames.*;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.AnyOf.anyOf;
@@ -617,7 +617,7 @@ public abstract class AbstractExtendedNettyMockingIntegrationTest extends Abstra
                 "GET " + calculatePath("") + " HTTP/1.1" + NEW_LINE +
                 "Content-Length: 0\r" + NEW_LINE +
                 "\r\n"
-            ).getBytes(Charsets.UTF_8));
+            ).getBytes(StandardCharsets.UTF_8));
             output.flush();
 
             // then
@@ -632,9 +632,9 @@ public abstract class AbstractExtendedNettyMockingIntegrationTest extends Abstra
             // and - socket is closed
             try {
                 // flush data to increase chance that Java / OS notice socket has been closed
-                output.write("some_random_bytes".getBytes(Charsets.UTF_8));
+                output.write("some_random_bytes".getBytes(StandardCharsets.UTF_8));
                 output.flush();
-                output.write("some_random_bytes".getBytes(Charsets.UTF_8));
+                output.write("some_random_bytes".getBytes(StandardCharsets.UTF_8));
                 output.flush();
 
                 TimeUnit.SECONDS.sleep(2);
@@ -662,7 +662,7 @@ public abstract class AbstractExtendedNettyMockingIntegrationTest extends Abstra
                 "GET " + calculatePath("") + " HTTP/1.1" + NEW_LINE +
                 "Content-Length: 0\r" + NEW_LINE +
                 "\r\n"
-            ).getBytes(Charsets.UTF_8));
+            ).getBytes(StandardCharsets.UTF_8));
             output.flush();
 
             // then
@@ -704,11 +704,11 @@ public abstract class AbstractExtendedNettyMockingIntegrationTest extends Abstra
                 "GET " + calculatePath("") + " HTTP/1.1" + NEW_LINE +
                 "Content-Length: 0\r" + NEW_LINE +
                 "\r\n"
-            ).getBytes(Charsets.UTF_8));
+            ).getBytes(StandardCharsets.UTF_8));
             output.flush();
 
             // then
-            assertThat(IOUtils.toString(socket.getInputStream(), Charsets.UTF_8.name()), is("some_random_bytes"));
+            assertThat(IOUtils.toString(socket.getInputStream(), StandardCharsets.UTF_8.name()), is("some_random_bytes"));
         } finally {
             if (socket != null) {
                 socket.close();
@@ -727,11 +727,11 @@ public abstract class AbstractExtendedNettyMockingIntegrationTest extends Abstra
                 "GET " + calculatePath("") + " HTTP/1.1" + NEW_LINE +
                 "Content-Length: 0\r" + NEW_LINE +
                 "\r\n"
-            ).getBytes(Charsets.UTF_8));
+            ).getBytes(StandardCharsets.UTF_8));
             output.flush();
 
             // then
-            assertThat(IOUtils.toString(sslSocket.getInputStream(), Charsets.UTF_8.name()), is("some_random_bytes"));
+            assertThat(IOUtils.toString(sslSocket.getInputStream(), StandardCharsets.UTF_8.name()), is("some_random_bytes"));
         } finally {
             if (sslSocket != null) {
                 sslSocket.close();
@@ -764,11 +764,11 @@ public abstract class AbstractExtendedNettyMockingIntegrationTest extends Abstra
                 "GET " + calculatePath("http_error") + " HTTP/1.1" + NEW_LINE +
                 "Content-Length: 0\r" + NEW_LINE +
                 "\r\n"
-            ).getBytes(Charsets.UTF_8));
+            ).getBytes(StandardCharsets.UTF_8));
             output.flush();
 
             // then
-            assertThat(IOUtils.toString(socket.getInputStream(), Charsets.UTF_8.name()), is("some_random_bytes"));
+            assertThat(IOUtils.toString(socket.getInputStream(), StandardCharsets.UTF_8.name()), is("some_random_bytes"));
         } finally {
             if (socket != null) {
                 socket.close();

--- a/mockserver-netty/src/test/java/org/mockserver/integration/proxy/direct/NettyPortForwardingProxyIntegrationTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/integration/proxy/direct/NettyPortForwardingProxyIntegrationTest.java
@@ -1,6 +1,5 @@
 package org.mockserver.integration.proxy.direct;
 
-import com.google.common.base.Charsets;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -10,6 +9,7 @@ import org.mockserver.streams.IOStreamUtils;
 
 import java.io.OutputStream;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 
 import static org.mockserver.test.Assert.assertContains;
 
@@ -55,7 +55,7 @@ public class NettyPortForwardingProxyIntegrationTest {
                 "Host: localhost:" + echoServer.getPort() + "\r\n" +
                 "X-Test: test_headers_only\r\n" +
                 "\r\n"
-            ).getBytes(Charsets.UTF_8));
+            ).getBytes(StandardCharsets.UTF_8));
             output.flush();
 
             // then
@@ -82,10 +82,10 @@ public class NettyPortForwardingProxyIntegrationTest {
                 "GET /test_headers_and_body HTTP/1.1\r\n" +
                 "Host: localhost:" + echoServer.getPort() + "\r\n" +
                 "X-Test: test_headers_and_body\r\n" +
-                "Content-Length:" + "an_example_body".getBytes(Charsets.UTF_8).length + "\r\n" +
+                "Content-Length:" + "an_example_body".getBytes(StandardCharsets.UTF_8).length + "\r\n" +
                 "\r\n" +
                 "an_example_body" + "\r\n"
-            ).getBytes(Charsets.UTF_8));
+            ).getBytes(StandardCharsets.UTF_8));
             output.flush();
 
             // then
@@ -114,7 +114,7 @@ public class NettyPortForwardingProxyIntegrationTest {
                 "GET /not_found HTTP/1.1\r\n" +
                 "Host: localhost:" + echoServer.getPort() + "\r\n" +
                 "\r\n"
-            ).getBytes(Charsets.UTF_8));
+            ).getBytes(StandardCharsets.UTF_8));
             output.flush();
 
             // then

--- a/mockserver-netty/src/test/java/org/mockserver/integration/proxy/direct/NettyPortForwardingSecureProxyIntegrationTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/integration/proxy/direct/NettyPortForwardingSecureProxyIntegrationTest.java
@@ -1,6 +1,5 @@
 package org.mockserver.integration.proxy.direct;
 
-import com.google.common.base.Charsets;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -11,6 +10,7 @@ import org.mockserver.streams.IOStreamUtils;
 
 import java.io.OutputStream;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.socket.SSLSocketFactory.sslSocketFactory;
@@ -62,7 +62,7 @@ public class NettyPortForwardingSecureProxyIntegrationTest {
                 "Host: localhost:" + echoServer.getPort() + "\r\n" +
                 "X-Test: test_headers_only\r\n" +
                 "\r\n"
-            ).getBytes(Charsets.UTF_8));
+            ).getBytes(StandardCharsets.UTF_8));
             output.flush();
 
             // then
@@ -97,10 +97,10 @@ public class NettyPortForwardingSecureProxyIntegrationTest {
                 "GET /test_headers_and_body HTTP/1.1\r\n" +
                 "Host: localhost:" + echoServer.getPort() + "\r\n" +
                 "X-Test: test_headers_and_body\r\n" +
-                "Content-Length:" + "an_example_body".getBytes(Charsets.UTF_8).length + "\r\n" +
+                "Content-Length:" + "an_example_body".getBytes(StandardCharsets.UTF_8).length + "\r\n" +
                 "\r\n" +
                 "an_example_body" + "\r\n"
-            ).getBytes(Charsets.UTF_8));
+            ).getBytes(StandardCharsets.UTF_8));
             output.flush();
 
             // then
@@ -138,7 +138,7 @@ public class NettyPortForwardingSecureProxyIntegrationTest {
                 "GET /not_found HTTP/1.1\r\n" +
                 "Host: localhost:" + echoServer.getPort() + "\r\n" +
                 "\r\n"
-            ).getBytes(Charsets.UTF_8));
+            ).getBytes(StandardCharsets.UTF_8));
             output.flush();
 
             // then

--- a/mockserver-netty/src/test/java/org/mockserver/integration/proxy/socks/NettyHttpProxySOCKSIntegrationTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/integration/proxy/socks/NettyHttpProxySOCKSIntegrationTest.java
@@ -1,6 +1,5 @@
 package org.mockserver.integration.proxy.socks;
 
-import com.google.common.base.Charsets;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -32,6 +31,7 @@ import org.mockserver.streams.IOStreamUtils;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.*;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 
@@ -234,7 +234,7 @@ public class NettyHttpProxySOCKSIntegrationTest {
 
         // then
         assertEquals(HttpStatusCode.OK_200.code(), response.getStatusLine().getStatusCode());
-        assertEquals("an_example_body", new String(EntityUtils.toByteArray(response.getEntity()), Charsets.UTF_8));
+        assertEquals("an_example_body", new String(EntityUtils.toByteArray(response.getEntity()), StandardCharsets.UTF_8));
 
         // and
         mockServerClient.verify(
@@ -302,7 +302,7 @@ public class NettyHttpProxySOCKSIntegrationTest {
 
         // then
         assertEquals(HttpStatusCode.OK_200.code(), response.getStatusLine().getStatusCode());
-        assertEquals("an_example_body", new String(EntityUtils.toByteArray(response.getEntity()), Charsets.UTF_8));
+        assertEquals("an_example_body", new String(EntityUtils.toByteArray(response.getEntity()), StandardCharsets.UTF_8));
 
         // and
         mockServerClient.verify(
@@ -356,10 +356,10 @@ public class NettyHttpProxySOCKSIntegrationTest {
                 "GET /test_headers_and_body HTTP/1.1\r\n" +
                 "Host: localhost:" + (useTLS ? secureEchoServer.getPort() : insecureEchoServer.getPort()) + "\r\n" +
                 "X-Test: test_headers_and_body\r\n" +
-                "Content-Length:" + "an_example_body".getBytes(Charsets.UTF_8).length + "\r\n" +
+                "Content-Length:" + "an_example_body".getBytes(StandardCharsets.UTF_8).length + "\r\n" +
                 "\r\n" +
                 "an_example_body" + "\r\n"
-            ).getBytes(Charsets.UTF_8));
+            ).getBytes(StandardCharsets.UTF_8));
             output.flush();
 
             // then

--- a/mockserver-netty/src/test/java/org/mockserver/proxy/direct/DirectProxyUnificationHandlerTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/proxy/direct/DirectProxyUnificationHandlerTest.java
@@ -22,7 +22,7 @@ import org.mockserver.unification.PortUnificationHandler;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.core.Is.is;

--- a/mockserver-netty/src/test/java/org/mockserver/proxy/http/HttpProxyUnificationInitializerSOCKSErrorTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/proxy/http/HttpProxyUnificationInitializerSOCKSErrorTest.java
@@ -20,7 +20,7 @@ import org.mockserver.proxy.socks.SocksProxyHandler;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.core.Is.is;

--- a/mockserver-netty/src/test/java/org/mockserver/proxy/http/HttpProxyUnificationInitializerTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/proxy/http/HttpProxyUnificationInitializerTest.java
@@ -20,7 +20,7 @@ import org.mockserver.proxy.socks.SocksProxyHandler;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.core.Is.is;


### PR DESCRIPTION
There isn't too much point to this PR except for a step in the direction of replacing all usages of Guava in Mockserver with builtin defaults. I think the ideal for a library is to be as dependency light as possible and so it is in that spirit that I offer this PR (if you are okay with the idea I shall tackle other Guava classes).

Thanks.