### PR TITLE
Changed mockserver CLI info to remove proxy info

### DIFF
--- a/jekyll-www.mock-server.com/mock_server/_includes/running_mock_server_detail.html
+++ b/jekyll-www.mock-server.com/mock_server/_includes/running_mock_server_detail.html
@@ -365,12 +365,8 @@
                                  INFO - all interactions
 
     -serverPort <span class="command_line_argument_placeholder">&lt;port&gt;</span>           Specifies the HTTP, HTTPS, SOCKS and HTTP
-                                 CONNECT port for proxy. Port unification
+                                 CONNECT port for server. Port unification
                                  supports for all protocols on the same port.
-
-    -proxyPort <span class="command_line_argument_placeholder">&lt;port&gt;</span>            Specifies the HTTP and HTTPS port for the
-                                 MockServer. Port unification is used to
-                                 support HTTP and HTTPS on the same port.
 
     -proxyRemotePort <span class="command_line_argument_placeholder">&lt;port&gt;</span>      Specifies the port to forward all proxy
                                  requests to (i.e. all requests received on
@@ -426,12 +422,8 @@ i.e. mockserver -logLevel INFO -serverPort <span class="numeric_literal">1080</s
 
  valid options are:
     -serverPort <span class="command_line_argument_placeholder">&lt;port&gt;</span>           Specifies the HTTP, HTTPS, SOCKS and HTTP
-                                 CONNECT port for proxy. Port unification
+                                 CONNECT port for server. Port unification
                                  supports for all protocols on the same port.
-
-    -proxyPort <span class="command_line_argument_placeholder">&lt;port&gt;</span>            Specifies the HTTP and HTTPS port for the
-                                 MockServer. Port unification is used to
-                                 support HTTP and HTTPS on the same port.
 
     -proxyRemotePort <span class="command_line_argument_placeholder">&lt;port&gt;</span>      Specifies the port to forward all proxy
                                  requests to (i.e. all requests received on


### PR DESCRIPTION
James,
This is a (very minor) change from that PR which you asked me to rebase.
I noticed that you removed the proxyServer option in CLI and just have one configuration.
This is a good simplification.  

So this PR simply removes the proxyServer from the 2 sections (brew and Java).

If you concur, please merge.
tx
jim
