### PR TITLE
Use a java version instead of just alpine

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@
 #
 
 # pull base image
-FROM openjdk:alpine
+FROM openjdk:8-jdk-alpine
 
 # maintainer details
 MAINTAINER James Bloom "jamesdbloom@gmail.com"


### PR DESCRIPTION
We need to stick with specific version in order to be sure to run the same versions across systems