### PR TITLE
ReplaceHeader ignoring case and add removeHeader

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/model/HttpResponse.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/HttpResponse.java
@@ -242,6 +242,11 @@ public class HttpResponse extends Action {
         return this;
     }
 
+    public HttpResponse removeHeader(String name) {
+        this.headers.removeEntry(name);
+        return this;
+    }
+
     public List<Header> getHeaderList() {
         return this.headers.getEntries();
     }

--- a/mockserver-core/src/main/java/org/mockserver/model/KeysToMultiValues.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/KeysToMultiValues.java
@@ -5,10 +5,7 @@ import com.google.common.collect.ListMultimap;
 import org.apache.commons.lang3.ArrayUtils;
 import org.mockserver.collections.CaseInsensitiveRegexMultiMap;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.mockserver.model.NottableString.*;
 
@@ -98,14 +95,48 @@ public abstract class KeysToMultiValues<T extends KeyToMultiValue, K extends Key
 
     public K replaceEntry(T entry) {
         if (entry != null) {
-            this.listMultimap.replaceValues(entry.getName(), entry.getValues());
+            NottableString nameCaseSensitive = null;
+            for (Map.Entry<NottableString, NottableString> searchEntry : listMultimap.entries()) {
+                if (searchEntry.getKey() != null &&
+                    searchEntry != null &&
+                    searchEntry.getKey().equalsIgnoreCase(entry.getName())) {
+                    nameCaseSensitive = searchEntry.getKey();
+                    break;
+                }
+            }
+
+            this.listMultimap.replaceValues(nameCaseSensitive, entry.getValues());
         }
         return (K) this;
     }
 
     public K replaceEntry(String name, String... values) {
         if (ArrayUtils.isNotEmpty(values)) {
-            this.listMultimap.replaceValues(string(name), deserializeNottableStrings(values));
+            NottableString nameCaseSensitive = null;
+            for (Map.Entry<NottableString, NottableString> entry : listMultimap.entries()) {
+                if (entry.getKey() != null &&
+                    name != null &&
+                    entry.getKey().equalsIgnoreCase(name)) {
+                    nameCaseSensitive = entry.getKey();
+                    break;
+                }
+            }
+
+            this.listMultimap.replaceValues(nameCaseSensitive, deserializeNottableStrings(values));
+        }
+        return (K) this;
+    }
+
+    public K removeEntry(String name) {
+        listMultimap.removeAll(string(name));
+        Iterator<NottableString> i = listMultimap.keySet().iterator();
+        while (i.hasNext()) {
+            NottableString entryName = i.next();
+            if (entryName != null &&
+                name != null &&
+                entryName.equalsIgnoreCase(name)) {
+                i.remove();
+            }
         }
         return (K) this;
     }

--- a/mockserver-core/src/test/java/org/mockserver/model/HttpResponseTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/model/HttpResponseTest.java
@@ -1,3 +1,4 @@
+
 package org.mockserver.model;
 
 import org.junit.Test;
@@ -119,6 +120,18 @@ public class HttpResponseTest {
         assertThat(new HttpResponse().withHeader(new Header("name", "valueOne")).replaceHeader(new Header("name", "valueTwo")).getHeaderList(), containsInAnyOrder(new Header("name", "valueTwo")));
         assertThat(new HttpResponse().withHeader(new Header("name", "valueOne")).replaceHeader("name", "valueTwo").getHeaderList(), containsInAnyOrder(new Header("name", "valueTwo")));
     }
+
+    @Test
+    public void updatesExistingHeaderIgnoringCase() {
+        assertThat(new HttpResponse().withHeader(new Header("NaMe", "valueOne")).replaceHeader(new Header("name", "valueTwo")).getHeaderList(), containsInAnyOrder(new Header("NaMe", "valueTwo")));
+        assertThat(new HttpResponse().withHeader(new Header("NaMe", "valueOne")).replaceHeader("name", "valueTwo").getHeaderList(), containsInAnyOrder(new Header("NaMe", "valueTwo")));
+    }
+
+    @Test
+    public void removeExistingHeaderIgnoringCase() {
+        assertThat(new HttpResponse().withHeader(new Header("NaMe", "valueOne")).removeHeader("name").getHeader("NaMe"), hasSize(0));
+    }
+
 
     @Test
     public void returnsCookies() {


### PR DESCRIPTION
This feature allow to replace a header ignoring case and add a removeHeader in the HttpResponse