### PR TITLE
Allow build on system with different mvn default locale

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -575,6 +575,7 @@
                         <mockserver.disableSystemOut>true</mockserver.disableSystemOut>
                         <mockserver.nioEventLoopThreadCount>1</mockserver.nioEventLoopThreadCount>
                     </systemProperties>
+                    <argLine>-Duser.language=en -Duser.country=GB</argLine>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
add argLine to maven-surefire-plugin so the project can be build on s…ystem with a different default locale for maven e.g. de_DE

with out this change the build fails with:
```
[ERROR] Failures:
[ERROR]   XmlSchemaValidatorTest.shouldHandleEmptyTest:157
Expected: is "Premature end of file."
     but: was "Vorzeitiges Dateiende."
[ERROR]   XmlSchemaValidatorTest.shouldHandleXmlExtraField:98
Expected: is "cvc-complex-type.2.4.a: Invalid content was found starting with element 'to'. One of '{from}' is expected."
     but: was "cvc-complex-type.2.4.a: Ungültiger Content wurde beginnend mit Element 'to' gefunden. '{from}' wird erwartet."
[ERROR]   XmlSchemaValidatorTest.shouldHandleXmlMissingRequiredFields:77
Expected: is "cvc-complex-type.2.4.a: Invalid content was found starting with element 'heading'. One of '{from}' is expected."
     but: was "cvc-complex-type.2.4.a: Ungültiger Content wurde beginnend mit Element 'heading' gefunden. '{from}' wird erwartet."
[INFO]
[ERROR] Tests run: 1460, Failures: 3, Errors: 0, Skipped: 0
```