### PR TITLE
Fixing typos around REPOSITORY_URL

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,9 +15,9 @@ MAINTAINER James Bloom "jamesdbloom@gmail.com"
 RUN apk add --update openssl ca-certificates bash wget
 ADD run_mockserver.sh /opt/mockserver/run_mockserver.sh
 ARG VERSION=5.3.0
-ARG RESPOSITORY_URL=https://oss.sonatype.org/content/repositories/releases/org/mock-server/mockserver-netty/$VERSION/mockserver-netty-$VERSION-jar-with-dependencies.jar
-RUN echo "using mockserver version $RESPOSITORY_URL"
-RUN wget --max-redirect=1 -O /opt/mockserver/mockserver-netty-jar-with-dependencies.jar $RESPOSITORY_URL
+ARG REPOSITORY_URL=https://oss.sonatype.org/content/repositories/releases/org/mock-server/mockserver-netty/$VERSION/mockserver-netty-$VERSION-jar-with-dependencies.jar
+RUN echo "using mockserver version $REPOSITORY_URL"
+RUN wget --max-redirect=1 -O /opt/mockserver/mockserver-netty-jar-with-dependencies.jar $REPOSITORY_URL
 
 # set working directory
 WORKDIR /opt/mockserver


### PR DESCRIPTION
Typo in env variable causes bugs by those extending or customizing Dockerfile.