### PR TITLE
fix invalid yaml format error

### DIFF
--- a/helm/mockserver/templates/deployment.yaml
+++ b/helm/mockserver/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: {{ template "mockserver.name" . }}
           image: {{ .Values.image.repository }}/mockserver:mockserver-{{- if .Values.image.snapshot }}snapshot{{- else }}{{ .Chart.Version }}{{- end }}
-          imagePullPolicy: {{- if .Values.image.snapshot }}Always{{- else }}{{ .Values.image.pullPolicy }}{{- end }}
+          imagePullPolicy: {{ if .Values.image.snapshot }}Always{{- else }}{{ .Values.image.pullPolicy }}{{- end }}
           ports:
             - name: serviceport
               containerPort: 1080


### PR DESCRIPTION
the minus sign `-` in go template has special meaning, `{{-` will cause all trailing white space  trimmed from the immediately preceding text,  and generate `imagePullPolicy:Always`(no white space after colon sign), which is not valid `key: value` yaml format.