### PR TITLE
(#512) Fixing file descriptor leak when using expectation callbacks

### DIFF
--- a/mockserver-client-java/src/main/java/org/mockserver/client/ForwardChainExpectation.java
+++ b/mockserver-client-java/src/main/java/org/mockserver/client/ForwardChainExpectation.java
@@ -1,6 +1,9 @@
 package org.mockserver.client;
 
 import com.google.common.annotations.VisibleForTesting;
+
+import org.mockserver.client.MockServerEventBus.MockServerEvent;
+import org.mockserver.client.MockServerEventBus.MockServerEventSubscriber;
 import org.mockserver.client.netty.websocket.WebSocketClient;
 import org.mockserver.client.netty.websocket.WebSocketException;
 import org.mockserver.mock.Expectation;
@@ -20,6 +23,15 @@ public class ForwardChainExpectation {
     public ForwardChainExpectation(MockServerClient mockServerClient, Expectation expectation) {
         this.mockServerClient = mockServerClient;
         this.expectation = expectation;
+        
+        MockServerEventBus.getInstance().subscribe(new MockServerEventSubscriber() {
+			@Override
+			public void handle() {
+				if (webSocketClient != null) {
+					webSocketClient.stopClient();
+				}
+			}
+		}, MockServerEvent.STOP, MockServerEvent.RESET);
     }
 
     /**

--- a/mockserver-client-java/src/main/java/org/mockserver/client/ForwardChainExpectation.java
+++ b/mockserver-client-java/src/main/java/org/mockserver/client/ForwardChainExpectation.java
@@ -25,13 +25,13 @@ public class ForwardChainExpectation {
         this.expectation = expectation;
         
         MockServerEventBus.getInstance().subscribe(new MockServerEventSubscriber() {
-			@Override
-			public void handle() {
-				if (webSocketClient != null) {
-					webSocketClient.stopClient();
-				}
-			}
-		}, MockServerEvent.STOP, MockServerEvent.RESET);
+            @Override
+            public void handle() {
+                if (webSocketClient != null) {
+                    webSocketClient.stopClient();
+                }
+            }
+        }, MockServerEvent.STOP, MockServerEvent.RESET);
     }
 
     /**

--- a/mockserver-client-java/src/main/java/org/mockserver/client/MockServerClient.java
+++ b/mockserver-client-java/src/main/java/org/mockserver/client/MockServerClient.java
@@ -198,7 +198,7 @@ public class MockServerClient implements java.io.Closeable {
      * Stop MockServer gracefully (only support for Netty version, not supported for WAR version)
      */
     public MockServerClient stop() {
-    	MockServerEventBus.getInstance().publish(MockServerEvent.STOP);
+        MockServerEventBus.getInstance().publish(MockServerEvent.STOP);
         return stop(false);
     }
 
@@ -230,7 +230,7 @@ public class MockServerClient implements java.io.Closeable {
      * Reset MockServer by clearing all expectations
      */
     public MockServerClient reset() {
-    	MockServerEventBus.getInstance().publish(MockServerEvent.RESET);
+        MockServerEventBus.getInstance().publish(MockServerEvent.RESET);
         sendRequest(request().withMethod("PUT").withPath(calculatePath("reset")));
         return clientClass.cast(this);
     }

--- a/mockserver-client-java/src/main/java/org/mockserver/client/MockServerClient.java
+++ b/mockserver-client-java/src/main/java/org/mockserver/client/MockServerClient.java
@@ -4,6 +4,7 @@ import com.google.common.base.Strings;
 import com.google.common.util.concurrent.SettableFuture;
 import org.apache.commons.lang3.StringUtils;
 import org.mockserver.Version;
+import org.mockserver.client.MockServerEventBus.MockServerEvent;
 import org.mockserver.client.netty.NettyHttpClient;
 import org.mockserver.client.netty.SocketConnectionException;
 import org.mockserver.client.serialization.*;
@@ -197,6 +198,7 @@ public class MockServerClient implements java.io.Closeable {
      * Stop MockServer gracefully (only support for Netty version, not supported for WAR version)
      */
     public MockServerClient stop() {
+    	MockServerEventBus.getInstance().publish(MockServerEvent.STOP);
         return stop(false);
     }
 
@@ -228,6 +230,7 @@ public class MockServerClient implements java.io.Closeable {
      * Reset MockServer by clearing all expectations
      */
     public MockServerClient reset() {
+    	MockServerEventBus.getInstance().publish(MockServerEvent.RESET);
         sendRequest(request().withMethod("PUT").withPath(calculatePath("reset")));
         return clientClass.cast(this);
     }

--- a/mockserver-client-java/src/main/java/org/mockserver/client/MockServerEventBus.java
+++ b/mockserver-client-java/src/main/java/org/mockserver/client/MockServerEventBus.java
@@ -1,72 +1,74 @@
 package org.mockserver.client;
 
-
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder.ListMultimapBuilder;
 
 /**
- * A publish/subscribe communication channel between {@link MockServerClient} and {@link ForwardChainExpectation} instances
+ * A publish/subscribe communication channel between {@link MockServerClient}
+ * and {@link ForwardChainExpectation} instances
  * 
  * Use {@link #getInstance()} to get the instance.
  * 
  * @author albans
  */
 final class MockServerEventBus {
-	private static MockServerEventBus INSTANCE;
+    private static MockServerEventBus instance;
 
-	private final Multimap<MockServerEvent, MockServerEventSubscriber> subscribers = ListMultimapBuilder
-			.enumKeys(MockServerEvent.class)
-			.arrayListValues()
-			.build();
+    private final Multimap<MockServerEvent, MockServerEventSubscriber> subscribers = ListMultimapBuilder
+            .enumKeys(MockServerEvent.class).arrayListValues().build();
 
-	/**
-	 * {@link MockServerEvent} subscribers pass an instance of an
-	 * implementation of this class to {@link MockServerEventBus#subscribe(MockServerEventSubscriber, MockServerEvent...)}
-	 * to subscribe to events
-	 */
-	static interface MockServerEventSubscriber {
-		void handle();
-	}
+    /**
+     * {@link MockServerEvent} subscribers pass an instance of an implementation of
+     * this class to
+     * {@link MockServerEventBus#subscribe(MockServerEventSubscriber, MockServerEvent...)}
+     * to subscribe to events
+     */
+    static interface MockServerEventSubscriber {
+        void handle();
+    }
 
-	/**
-	 * Enumeration of events handled by this bus.
-	 */
-	static enum MockServerEvent {
-		STOP, RESET;
-	}
+    /**
+     * Enumeration of events handled by this bus.
+     */
+    static enum MockServerEvent {
+        STOP, RESET;
+    }
 
-	private MockServerEventBus() {
-	}
+    private MockServerEventBus() {
+    }
 
-	/**
-	 * Return the instance of {@link MockServerEventBus}.
-	 * @return instance
-	 */
-	public static MockServerEventBus getInstance() {
-		if (INSTANCE == null) {
-			INSTANCE = new MockServerEventBus();
-		}
-		return INSTANCE;
-	}
+    /**
+     * Return the instance of {@link MockServerEventBus}.
+     * 
+     * @return instance
+     */
+    public static MockServerEventBus getInstance() {
+        if (instance == null) {
+            instance = new MockServerEventBus();
+        }
+        return instance;
+    }
 
-	/**
-	 * Publish the event given as parameter.
-	 * @param event
-	 */
-	public void publish(MockServerEvent event) {
-		for (MockServerEventSubscriber subscriber : subscribers.get(event)) {
-			subscriber.handle();
-		}
-	}
+    /**
+     * Publish the event given as parameter.
+     * 
+     * @param event
+     */
+    public void publish(MockServerEvent event) {
+        for (MockServerEventSubscriber subscriber : subscribers.get(event)) {
+            subscriber.handle();
+        }
+    }
 
-	/**
-	 * Subscribe the the events given as parameters using the  given subscriber.
-	 * @param subscriber
-	 * @param events 
-	 */
-	public void subscribe(MockServerEventSubscriber subscriber, MockServerEvent... events) {
-		for (MockServerEvent event : events) {
-			subscribers.put(event, subscriber);
-		}
-	}
+    /**
+     * Subscribe the the events given as parameters using the given subscriber.
+     * 
+     * @param subscriber
+     * @param events
+     */
+    public void subscribe(MockServerEventSubscriber subscriber, MockServerEvent... events) {
+        for (MockServerEvent event : events) {
+            subscribers.put(event, subscriber);
+        }
+    }
 }

--- a/mockserver-client-java/src/main/java/org/mockserver/client/MockServerEventBus.java
+++ b/mockserver-client-java/src/main/java/org/mockserver/client/MockServerEventBus.java
@@ -1,0 +1,72 @@
+package org.mockserver.client;
+
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder.ListMultimapBuilder;
+
+/**
+ * A publish/subscribe communication channel between {@link MockServerClient} and {@link ForwardChainExpectation} instances
+ * 
+ * Use {@link #getInstance()} to get the instance.
+ * 
+ * @author albans
+ */
+final class MockServerEventBus {
+	private static MockServerEventBus INSTANCE;
+
+	private final Multimap<MockServerEvent, MockServerEventSubscriber> subscribers = ListMultimapBuilder
+			.enumKeys(MockServerEvent.class)
+			.arrayListValues()
+			.build();
+
+	/**
+	 * {@link MockServerEvent} subscribers pass an instance of an
+	 * implementation of this class to {@link MockServerEventBus#subscribe(MockServerEventSubscriber, MockServerEvent...)}
+	 * to subscribe to events
+	 */
+	static interface MockServerEventSubscriber {
+		void handle();
+	}
+
+	/**
+	 * Enumeration of events handled by this bus.
+	 */
+	static enum MockServerEvent {
+		STOP, RESET;
+	}
+
+	private MockServerEventBus() {
+	}
+
+	/**
+	 * Return the instance of {@link MockServerEventBus}.
+	 * @return instance
+	 */
+	public static MockServerEventBus getInstance() {
+		if (INSTANCE == null) {
+			INSTANCE = new MockServerEventBus();
+		}
+		return INSTANCE;
+	}
+
+	/**
+	 * Publish the event given as parameter.
+	 * @param event
+	 */
+	public void publish(MockServerEvent event) {
+		for (MockServerEventSubscriber subscriber : subscribers.get(event)) {
+			subscriber.handle();
+		}
+	}
+
+	/**
+	 * Subscribe the the events given as parameters using the  given subscriber.
+	 * @param subscriber
+	 * @param events 
+	 */
+	public void subscribe(MockServerEventSubscriber subscriber, MockServerEvent... events) {
+		for (MockServerEvent event : events) {
+			subscribers.put(event, subscriber);
+		}
+	}
+}

--- a/mockserver-client-java/src/test/java/org/mockserver/client/MockServerClientTest.java
+++ b/mockserver-client-java/src/test/java/org/mockserver/client/MockServerClientTest.java
@@ -1,5 +1,34 @@
 package org.mockserver.client;
 
+import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.CREATED;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockserver.model.HttpOverrideForwardedRequest.forwardOverriddenRequest;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.verify.Verification.verification;
+import static org.mockserver.verify.VerificationTimes.atLeast;
+import static org.mockserver.verify.VerificationTimes.once;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -14,36 +43,36 @@ import org.mockserver.client.serialization.ExpectationSerializer;
 import org.mockserver.client.serialization.HttpRequestSerializer;
 import org.mockserver.client.serialization.VerificationSequenceSerializer;
 import org.mockserver.client.serialization.VerificationSerializer;
-import org.mockserver.client.serialization.model.*;
+import org.mockserver.client.serialization.model.ExpectationDTO;
+import org.mockserver.client.serialization.model.HttpClassCallbackDTO;
+import org.mockserver.client.serialization.model.HttpErrorDTO;
+import org.mockserver.client.serialization.model.HttpForwardDTO;
+import org.mockserver.client.serialization.model.HttpObjectCallbackDTO;
+import org.mockserver.client.serialization.model.HttpOverrideForwardedRequestDTO;
+import org.mockserver.client.serialization.model.HttpRequestDTO;
+import org.mockserver.client.serialization.model.HttpResponseDTO;
 import org.mockserver.matchers.Times;
 import org.mockserver.mock.Expectation;
 import org.mockserver.mock.action.ExpectationForwardCallback;
 import org.mockserver.mock.action.ExpectationResponseCallback;
-import org.mockserver.model.*;
+import org.mockserver.model.Action;
+import org.mockserver.model.ClearType;
+import org.mockserver.model.Format;
+import org.mockserver.model.Header;
+import org.mockserver.model.HttpClassCallback;
+import org.mockserver.model.HttpError;
+import org.mockserver.model.HttpForward;
+import org.mockserver.model.HttpObjectCallback;
+import org.mockserver.model.HttpOverrideForwardedRequest;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.mockserver.model.HttpStatusCode;
+import org.mockserver.model.HttpTemplate;
+import org.mockserver.model.RetrieveType;
+import org.mockserver.model.StringBody;
 import org.mockserver.verify.Verification;
 import org.mockserver.verify.VerificationSequence;
 import org.mockserver.verify.VerificationTimes;
-
-import java.nio.charset.StandardCharsets;
-import java.util.concurrent.TimeUnit;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
-import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static io.netty.handler.codec.http.HttpResponseStatus.CREATED;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
-import static org.mockserver.model.HttpOverrideForwardedRequest.forwardOverriddenRequest;
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
-import static org.mockserver.verify.Verification.verification;
-import static org.mockserver.verify.VerificationTimes.atLeast;
-import static org.mockserver.verify.VerificationTimes.once;
 
 /**
  * @author jamesdbloom

--- a/mockserver-client-java/src/test/java/org/mockserver/client/MockServerClientTest.java
+++ b/mockserver-client-java/src/test/java/org/mockserver/client/MockServerClientTest.java
@@ -893,7 +893,7 @@ public class MockServerClientTest {
             TimeUnit.MILLISECONDS
         );
     }
-
+    
     @Test
     public void shouldSendClearRequest() {
         // given
@@ -1317,5 +1317,31 @@ public class MockServerClientTest {
 
         // when
         mockServerClient.verify();
+    }
+    
+    @Test
+    public void shoudStopWebSocketClientWhenResetAndGivenWebsocketClient() {
+    	// given
+    	WebSocketClient webSocketClient = mock(WebSocketClient.class);
+		mockServerClient.when(request()).setWebSocketClient(webSocketClient);
+		
+		// when
+		mockServerClient.reset();
+		
+		// then
+		verify(webSocketClient).stopClient();
+    }
+    
+    @Test
+    public void shoudStopWebSocketClientWhenStopAndGivenWebsocketClient() {
+    	// given
+    	WebSocketClient webSocketClient = mock(WebSocketClient.class);
+		mockServerClient.when(request()).setWebSocketClient(webSocketClient);
+		
+		// when
+		mockServerClient.stop();
+		
+		// then
+		verify(webSocketClient).stopClient();
     }
 }

--- a/mockserver-client-java/src/test/java/org/mockserver/client/MockServerEventBusTest.java
+++ b/mockserver-client-java/src/test/java/org/mockserver/client/MockServerEventBusTest.java
@@ -1,0 +1,82 @@
+package org.mockserver.client;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockserver.client.MockServerEventBus.MockServerEvent.RESET;
+import static org.mockserver.client.MockServerEventBus.MockServerEvent.STOP;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockserver.client.MockServerEventBus.MockServerEventSubscriber;
+
+/**
+ * @author albans
+ */
+public class MockServerEventBusTest {
+	@Mock
+	private MockServerEventSubscriber subscriber;
+	
+	@Mock
+	private MockServerEventSubscriber secondSubscriber;
+	
+	private MockServerEventBus bus;
+	
+	@Before
+	public void setupTestFixture() {
+		bus = MockServerEventBus.getInstance();
+		
+		initMocks(this);
+	}
+
+	@Test
+	public void shouldPublishStopEventWhenNoRegisterSubscriber() {
+		// given no subscriber registered yet
+		
+		// when
+		bus.publish(STOP);
+		
+		// then nothing, no exception
+	}
+	
+	@Test
+	public void shoudPublishStopEventToOneRegisteredSubscriber() {
+		// given
+		bus.subscribe(subscriber, STOP);
+		
+		// when
+		bus.publish(STOP);
+		
+		// then
+		verify(subscriber).handle();
+	}
+	
+	@Test
+	public void shouldPublishResetEventToTwoSubscribers() {
+		// given
+		bus.subscribe(subscriber, RESET, STOP);
+		bus.subscribe(subscriber, RESET, STOP);
+		
+		// when
+		bus.publish(RESET);
+		
+		// then
+		verify(subscriber, times(2)).handle();
+	}
+	
+	@Test
+	public void shouldPublishEventToCorrectConsumer() {
+		// given
+		bus.subscribe(subscriber, RESET);
+		bus.subscribe(secondSubscriber, STOP);
+		
+		// when
+		bus.publish(STOP);
+		
+		// then
+		verify(subscriber, never()).handle();
+		verify(secondSubscriber).handle();
+	}
+}

--- a/mockserver-core/src/main/java/org/mockserver/client/netty/websocket/WebSocketClient.java
+++ b/mockserver-core/src/main/java/org/mockserver/client/netty/websocket/WebSocketClient.java
@@ -88,14 +88,15 @@ public class WebSocketClient {
     }
 
     public void stopClient() {
+    	group.shutdownGracefully();
         try {
             if (channel != null) {
-                channel.closeFuture().sync();
+                channel.close().sync();
+                channel = null;
             }
         } catch (InterruptedException e) {
             throw new WebSocketException("Exception while closing client", e);
         }
-        group.shutdownGracefully();
     }
 
     public WebSocketClient registerExpectationCallback(ExpectationResponseCallback expectationResponseCallback) {

--- a/mockserver-core/src/main/java/org/mockserver/client/netty/websocket/WebSocketClient.java
+++ b/mockserver-core/src/main/java/org/mockserver/client/netty/websocket/WebSocketClient.java
@@ -88,9 +88,11 @@ public class WebSocketClient {
     }
 
     public void stopClient() {
-    	group.shutdownGracefully();
+        if (!group.isShuttingDown() || group.isShutdown()) {
+            group.shutdownGracefully();
+        }
         try {
-            if (channel != null) {
+            if (channel != null && channel.isOpen()) {
                 channel.close().sync();
                 channel = null;
             }

--- a/mockserver-core/src/main/java/org/mockserver/echo/http/EchoServer.java
+++ b/mockserver-core/src/main/java/org/mockserver/echo/http/EchoServer.java
@@ -35,7 +35,8 @@ public class EchoServer {
     private final OnlyResponse onlyResponse = new OnlyResponse();
     private final NioEventLoopGroup eventLoopGroup = new NioEventLoopGroup();
     private final SettableFuture<Integer> boundPort = SettableFuture.create();
-
+    private EventLoopGroup bossGroup;
+    private EventLoopGroup workerGroup;
 
     public EchoServer(final boolean secure) {
         this(secure, null);
@@ -45,8 +46,8 @@ public class EchoServer {
         new Thread(new Runnable() {
             @Override
             public void run() {
-                EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-                EventLoopGroup workerGroup = new NioEventLoopGroup();
+                bossGroup = new NioEventLoopGroup(1);
+                workerGroup = new NioEventLoopGroup();
                 new ServerBootstrap().group(bossGroup, workerGroup)
                     .channel(NioServerSocketChannel.class)
                     .option(ChannelOption.SO_BACKLOG, 100)
@@ -81,6 +82,8 @@ public class EchoServer {
 
     public void stop() {
         scheduler.shutdown();
+        bossGroup.shutdownGracefully();
+        workerGroup.shutdownGracefully();
         eventLoopGroup.shutdownGracefully(0, 1, TimeUnit.MILLISECONDS);
     }
 

--- a/mockserver-core/src/main/java/org/mockserver/file/FileReader.java
+++ b/mockserver-core/src/main/java/org/mockserver/file/FileReader.java
@@ -11,8 +11,8 @@ import java.nio.charset.StandardCharsets;
 public class FileReader {
 
     public static String readFileFromClassPathOrPath(String filePath) {
-        try {
-            return IOUtils.toString(openStreamToFileFromClassPathOrPath(filePath), StandardCharsets.UTF_8.name());
+        try (InputStream inputStream = openStreamToFileFromClassPathOrPath(filePath)) {
+            return IOUtils.toString(inputStream, StandardCharsets.UTF_8.name());
         } catch (IOException ioe) {
             throw new RuntimeException("Exception while loading \"" + filePath + "\"", ioe);
         }

--- a/mockserver-netty/src/main/java/org/mockserver/integration/ClientAndServer.java
+++ b/mockserver-netty/src/main/java/org/mockserver/integration/ClientAndServer.java
@@ -38,6 +38,12 @@ public class ClientAndServer extends MockServerClient {
         return mockServer.isRunning();
     }
 
+    @Override
+    public MockServerClient stop() {
+        mockServer.stop();
+        return super.stop();
+    }
+    
     /**
      * @deprecated use getLocalPort instead of getPort
      */


### PR DESCRIPTION
Limitations:
- The EventLoopGroup is closed asynchrounously therefore it is still possible to run out of file
descriptors by creating expetation/resetting the client repeatedly.
- mockServerClient.clear may still leave open websockets and event loops.