### PR TITLE
Properly handle HttpRequest.withHeader calls without values (#521)

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/model/HttpRequest.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/HttpRequest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
 import static org.mockserver.character.Character.NEW_LINE;
+import static org.mockserver.model.Header.header;
 import static org.mockserver.model.NottableString.string;
 
 /**
@@ -408,7 +409,7 @@ public class HttpRequest extends Not {
      * @param values the header values which can be a varags of strings or regular expressions
      */
     public HttpRequest withHeader(String name, String... values) {
-        this.headers.withEntry(name, values);
+        this.headers.withEntry(header(name, values));
         return this;
     }
 
@@ -422,7 +423,7 @@ public class HttpRequest extends Not {
      * @param values the header values which can be a varags of NottableStrings
      */
     public HttpRequest withHeader(NottableString name, NottableString... values) {
-        this.headers.withEntry(name, values);
+        this.headers.withEntry(header(name, values));
         return this;
     }
 

--- a/mockserver-core/src/test/java/org/mockserver/model/HttpRequestTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/model/HttpRequestTest.java
@@ -71,6 +71,8 @@ public class HttpRequestTest {
         assertEquals(new Header("name", "value"), new HttpRequest().withHeaders(Arrays.asList(new Header("name", "value"))).getHeaderList().get(0));
         assertEquals(new Header("name", "value"), new HttpRequest().withHeader(new Header("name", "value")).getHeaderList().get(0));
         assertEquals(new Header("name", "value"), new HttpRequest().withHeader("name", "value").getHeaderList().get(0));
+        assertEquals(new Header("name", ".*"), new HttpRequest().withHeader(string("name")).getHeaderList().get(0));
+        assertEquals(new Header("name", ".*"), new HttpRequest().withHeader("name").getHeaderList().get(0));
         assertEquals(new Header("name", "value_one", "value_two"), new HttpRequest().withHeader(new Header("name", "value_one")).withHeader(new Header("name", "value_two")).getHeaderList().get(0));
         assertEquals(new Header("name", "value_one", "value_two"), new HttpRequest().withHeader(new Header("name", "value_one")).withHeader("name", "value_two").getHeaderList().get(0));
         assertEquals(new Header("name", "value_one", "value_two"), new HttpRequest().withHeaders(new Header("name", "value_one", "value_two")).getHeaderList().get(0));


### PR DESCRIPTION
fixes #521