### PR TITLE
Added the HTTPS support when MockServerClient send commands to MockSever

### DIFF
--- a/mockserver-client-java/src/main/java/org/mockserver/client/ForwardChainExpectation.java
+++ b/mockserver-client-java/src/main/java/org/mockserver/client/ForwardChainExpectation.java
@@ -78,9 +78,8 @@ public class ForwardChainExpectation {
      * @param expectationResponseCallback object to call locally or remotely to generate response
      */
     public void respond(ExpectationResponseCallback expectationResponseCallback) {
-        if (webSocketClient == null) {
-            webSocketClient = new WebSocketClient(mockServerClient.remoteAddress(), mockServerClient.contextPath());
-        }
+        initWebSocketClient();
+
         try {
             expectation.thenRespond(new HttpObjectCallback()
                 .withClientId(
@@ -139,9 +138,8 @@ public class ForwardChainExpectation {
      * @param expectationForwardCallback object to call locally or remotely to generate request
      */
     public void forward(ExpectationForwardCallback expectationForwardCallback) {
-        if (webSocketClient == null) {
-            webSocketClient = new WebSocketClient(mockServerClient.remoteAddress(), mockServerClient.contextPath());
-        }
+        initWebSocketClient();
+
         try {
             expectation.thenForward(new HttpObjectCallback()
                 .withClientId(
@@ -175,6 +173,16 @@ public class ForwardChainExpectation {
     public void error(HttpError httpError) {
         expectation.thenError(httpError);
         mockServerClient.sendExpectation(expectation);
+    }
+
+    private void initWebSocketClient() {
+        if (webSocketClient == null) {
+            webSocketClient = new WebSocketClient(
+                mockServerClient.remoteAddress(),
+                mockServerClient.contextPath(),
+                mockServerClient.isSecure()
+            );
+        }
     }
 
     @VisibleForTesting


### PR DESCRIPTION
Currently, the MockServerClient does not support HTTPS to contact MockServer to configure expectations, reset, and so on.

We need to establish an HTTPS connection between the MockServerClient and the MockServer as our MockServer is hosted on OpenShift with standard configuration without the possibility to do HTTP communications.

This PR introduces the possibility to set the MockServerClient in a secure way where all the requests done by the client to the MockServer are flagged "secure".