### PR TITLE
Provide SOCKS4 and SOCKS4a support and improve SOCKS5 support (#528, #529, #531)

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/configuration/ConfigurationProperties.java
+++ b/mockserver-core/src/main/java/org/mockserver/configuration/ConfigurationProperties.java
@@ -180,8 +180,8 @@ public class ConfigurationProperties {
 
     public static void addSslSubjectAlternativeNameIps(String... newSubjectAlternativeNameIps) {
         boolean subjectAlternativeIpsModified = false;
-        for (String subjectAlternativeDomain : newSubjectAlternativeNameIps) {
-            if (ALL_SUBJECT_ALTERNATIVE_IPS.add(subjectAlternativeDomain.trim())) {
+        for (String subjectAlternativeIp : newSubjectAlternativeNameIps) {
+            if (ALL_SUBJECT_ALTERNATIVE_IPS.add(subjectAlternativeIp.trim())) {
                 subjectAlternativeIpsModified = true;
             }
         }
@@ -278,6 +278,22 @@ public class ConfigurationProperties {
 
     public static void httpProxyServerPassword(String httpProxyServerPassword) {
         System.setProperty("mockserver.httpProxyServerPassword", httpProxyServerPassword);
+    }
+
+    public static String socksProxyServerUsername() {
+        return readPropertyHierarchically("mockserver.socksProxyServerUsername", "");
+    }
+
+    public static void socksProxyServerUsername(String socksProxyServerUsername) {
+        System.setProperty("mockserver.socksProxyServerUsername", socksProxyServerUsername);
+    }
+
+    public static String socksProxyServerPassword() {
+        return readPropertyHierarchically("mockserver.socksProxyServerPassword", "");
+    }
+
+    public static void socksProxyServerPassword(String socksProxyServerPassword) {
+        System.setProperty("mockserver.socksProxyServerPassword", socksProxyServerPassword);
     }
 
     private static InetSocketAddress readInetSocketAddressProperty(String s) {

--- a/mockserver-core/src/test/java/org/mockserver/configuration/ConfigurationPropertiesTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/configuration/ConfigurationPropertiesTest.java
@@ -497,4 +497,32 @@ public class ConfigurationPropertiesTest {
         assertEquals("p@ssw0rd", ConfigurationProperties.httpProxyServerPassword());
         assertEquals("p@ssw0rd", System.getProperty("mockserver.httpProxyServerPassword"));
     }
+
+    @Test
+    public void shouldSetAndReadSocksProxyServerUsername() {
+        // given
+        System.clearProperty("mockserver.socksProxyServerUsername");
+
+        // when
+        assertEquals("", ConfigurationProperties.socksProxyServerUsername());
+        ConfigurationProperties.socksProxyServerUsername("john.doe");
+
+        // then
+        assertEquals("john.doe", ConfigurationProperties.socksProxyServerUsername());
+        assertEquals("john.doe", System.getProperty("mockserver.socksProxyServerUsername"));
+    }
+
+    @Test
+    public void shouldSetAndReadSocksProxyServerPassword() {
+        // given
+        System.clearProperty("mockserver.socksProxyServerPassword");
+
+        // when
+        assertEquals("", ConfigurationProperties.socksProxyServerPassword());
+        ConfigurationProperties.socksProxyServerPassword("p@ssw0rd");
+
+        // then
+        assertEquals("p@ssw0rd", ConfigurationProperties.socksProxyServerPassword());
+        assertEquals("p@ssw0rd", System.getProperty("mockserver.socksProxyServerPassword"));
+    }
 }

--- a/mockserver-examples/src/test/java/org/mockserver/examples/proxy/web/controller/BooksPageEndToEndIntegrationTest.java
+++ b/mockserver-examples/src/test/java/org/mockserver/examples/proxy/web/controller/BooksPageEndToEndIntegrationTest.java
@@ -17,6 +17,11 @@ import org.springframework.web.context.WebApplicationContext;
 
 import javax.annotation.Resource;
 
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assume.assumeThat;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.verify.VerificationTimes.exactly;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -57,6 +62,12 @@ public abstract class BooksPageEndToEndIntegrationTest {
 
     @Test
     public void shouldLoadListOfBooks() throws Exception {
+        assumeThat("SOCKS5 is broken in JRE <9", System.getProperty("java.version"), not(anyOf(
+            startsWith("1.7."), equalTo("1.7"),
+            startsWith("7."), equalTo("7"),
+            startsWith("1.8."), equalTo("1.8"),
+            startsWith("8."), equalTo("8"))));
+
         // when
         MvcResult response = mockMvc.perform(get("/books").accept(MediaType.TEXT_HTML))
             .andExpect(status().isOk())
@@ -75,6 +86,12 @@ public abstract class BooksPageEndToEndIntegrationTest {
 
     @Test
     public void shouldLoadSingleBook() throws Exception {
+        assumeThat("SOCKS5 is broken in JRE <9", System.getProperty("java.version"), not(anyOf(
+            startsWith("1.7."), equalTo("1.7"),
+            startsWith("7."), equalTo("7"),
+            startsWith("1.8."), equalTo("1.8"),
+            startsWith("8."), equalTo("8"))));
+
         // when
         MvcResult response = mockMvc.perform(get("/book/1").accept(MediaType.TEXT_HTML))
             .andExpect(status().isOk())

--- a/mockserver-netty/src/main/java/org/mockserver/mockserver/MockServerHandler.java
+++ b/mockserver-netty/src/main/java/org/mockserver/mockserver/MockServerHandler.java
@@ -40,7 +40,7 @@ import static org.mockserver.exception.ExceptionHandler.shouldNotIgnoreException
 import static org.mockserver.mock.HttpStateHandler.PATH_PREFIX;
 import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.model.PortBinding.portBinding;
-import static org.mockserver.unification.PortUnificationHandler.enabledSslUpstreamAndDownstream;
+import static org.mockserver.unification.PortUnificationHandler.enableSslUpstreamAndDownstream;
 
 /**
  * @author jamesdbloom
@@ -146,7 +146,7 @@ public class MockServerHandler extends SimpleChannelInboundHandler<HttpRequest> 
                     } else {
                         ctx.channel().attr(PROXYING).set(Boolean.TRUE);
                         // assume SSL for CONNECT request
-                        enabledSslUpstreamAndDownstream(ctx.channel());
+                        enableSslUpstreamAndDownstream(ctx.channel());
                         // add Subject Alternative Name for SSL certificate
                         server.getScheduler().submit(new Runnable() {
                             @Override

--- a/mockserver-netty/src/main/java/org/mockserver/mockserver/MockServerUnificationInitializerDelegate.java
+++ b/mockserver-netty/src/main/java/org/mockserver/mockserver/MockServerUnificationInitializerDelegate.java
@@ -1,0 +1,37 @@
+package org.mockserver.mockserver;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import org.mockserver.callback.CallbackWebSocketServerHandler;
+import org.mockserver.client.netty.proxy.ProxyConfiguration;
+import org.mockserver.dashboard.DashboardWebSocketServerHandler;
+import org.mockserver.lifecycle.LifeCycle;
+import org.mockserver.mock.HttpStateHandler;
+import org.mockserver.server.netty.codec.MockServerServerCodec;
+import org.mockserver.unification.PortUnificationHandler;
+
+/**
+ * @author jamesdbloom
+ */
+public class MockServerUnificationInitializerDelegate extends PortUnificationHandler {
+
+    private CallbackWebSocketServerHandler callbackWebSocketServerHandler;
+    private DashboardWebSocketServerHandler uiWebSocketServerHandler;
+    private MockServerHandler mockServerHandler;
+
+    public MockServerUnificationInitializerDelegate(LifeCycle server, HttpStateHandler httpStateHandler, ProxyConfiguration proxyConfiguration) {
+        super(server, httpStateHandler.getMockServerLogger());
+        callbackWebSocketServerHandler = new CallbackWebSocketServerHandler(httpStateHandler);
+        uiWebSocketServerHandler = new DashboardWebSocketServerHandler(httpStateHandler);
+        mockServerHandler = new MockServerHandler(server, httpStateHandler, proxyConfiguration);
+    }
+
+    @Override
+    protected void configurePipeline(ChannelHandlerContext ctx, ChannelPipeline pipeline) {
+        pipeline.addLast(callbackWebSocketServerHandler);
+        pipeline.addLast(uiWebSocketServerHandler);
+        pipeline.addLast(new MockServerServerCodec(mockServerLogger, isSslEnabledUpstream(ctx.channel())));
+        pipeline.addLast(mockServerHandler);
+    }
+
+}

--- a/mockserver-netty/src/main/java/org/mockserver/proxy/socks/Socks4ConnectHandler.java
+++ b/mockserver-netty/src/main/java/org/mockserver/proxy/socks/Socks4ConnectHandler.java
@@ -1,0 +1,31 @@
+package org.mockserver.proxy.socks;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.socksx.v4.DefaultSocks4CommandResponse;
+import io.netty.handler.codec.socksx.v4.Socks4CommandRequest;
+import io.netty.handler.codec.socksx.v4.Socks4CommandStatus;
+import io.netty.handler.codec.socksx.v4.Socks4ServerEncoder;
+import org.mockserver.lifecycle.LifeCycle;
+import org.mockserver.logging.MockServerLogger;
+
+@ChannelHandler.Sharable
+public final class Socks4ConnectHandler extends SocksConnectHandler<Socks4CommandRequest> {
+
+    public Socks4ConnectHandler(LifeCycle server, MockServerLogger mockServerLogger, String host, int port) {
+        super(server, mockServerLogger, host, port);
+    }
+
+    protected void removeCodecSupport(ChannelHandlerContext ctx) {
+        super.removeCodecSupport(ctx);
+        removeHandler(ctx.pipeline(), Socks4ServerEncoder.class);
+    }
+
+    protected Object successResponse(Object request) {
+        return new DefaultSocks4CommandResponse(Socks4CommandStatus.SUCCESS);
+    }
+
+    protected Object failureResponse(Object request) {
+        return new DefaultSocks4CommandResponse(Socks4CommandStatus.REJECTED_OR_FAILED);
+    }
+}

--- a/mockserver-netty/src/main/java/org/mockserver/proxy/socks/Socks4ProxyHandler.java
+++ b/mockserver-netty/src/main/java/org/mockserver/proxy/socks/Socks4ProxyHandler.java
@@ -1,0 +1,29 @@
+package org.mockserver.proxy.socks;
+
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.socksx.v4.DefaultSocks4CommandResponse;
+import io.netty.handler.codec.socksx.v4.Socks4CommandRequest;
+import io.netty.handler.codec.socksx.v4.Socks4CommandStatus;
+import io.netty.handler.codec.socksx.v4.Socks4CommandType;
+import org.mockserver.lifecycle.LifeCycle;
+import org.mockserver.logging.MockServerLogger;
+
+@ChannelHandler.Sharable
+public class Socks4ProxyHandler extends SocksProxyHandler<Socks4CommandRequest> {
+
+    public Socks4ProxyHandler(LifeCycle server, MockServerLogger mockServerLogger) {
+        super(server, mockServerLogger);
+    }
+
+    @Override
+    protected void channelRead0(final ChannelHandlerContext ctx, final Socks4CommandRequest commandRequest) {
+        if (commandRequest.type().equals(Socks4CommandType.CONNECT)) {
+            forwardConnection(ctx, new Socks4ConnectHandler(server, mockServerLogger, commandRequest.dstAddr(), commandRequest.dstPort()), commandRequest.dstAddr(), commandRequest.dstPort());
+            ctx.fireChannelRead(commandRequest);
+        } else {
+            ctx.writeAndFlush(new DefaultSocks4CommandResponse(Socks4CommandStatus.REJECTED_OR_FAILED)).addListener(ChannelFutureListener.CLOSE);
+        }
+    }
+}

--- a/mockserver-netty/src/main/java/org/mockserver/proxy/socks/Socks5ConnectHandler.java
+++ b/mockserver-netty/src/main/java/org/mockserver/proxy/socks/Socks5ConnectHandler.java
@@ -1,0 +1,32 @@
+package org.mockserver.proxy.socks;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.socksx.v5.DefaultSocks5CommandResponse;
+import io.netty.handler.codec.socksx.v5.Socks5AddressType;
+import io.netty.handler.codec.socksx.v5.Socks5CommandRequest;
+import io.netty.handler.codec.socksx.v5.Socks5CommandStatus;
+import io.netty.handler.codec.socksx.v5.Socks5ServerEncoder;
+import org.mockserver.lifecycle.LifeCycle;
+import org.mockserver.logging.MockServerLogger;
+
+@ChannelHandler.Sharable
+public final class Socks5ConnectHandler extends SocksConnectHandler<Socks5CommandRequest> {
+
+    public Socks5ConnectHandler(LifeCycle server, MockServerLogger mockServerLogger, String host, int port) {
+        super(server, mockServerLogger, host, port);
+    }
+
+    protected void removeCodecSupport(ChannelHandlerContext ctx) {
+        super.removeCodecSupport(ctx);
+        removeHandler(ctx.pipeline(), Socks5ServerEncoder.class);
+    }
+
+    protected Object successResponse(Object request) {
+        return new DefaultSocks5CommandResponse(Socks5CommandStatus.SUCCESS, Socks5AddressType.DOMAIN, "", 0);
+    }
+
+    protected Object failureResponse(Object request) {
+        return new DefaultSocks5CommandResponse(Socks5CommandStatus.FAILURE, Socks5AddressType.DOMAIN, "", 0);
+    }
+}

--- a/mockserver-netty/src/main/java/org/mockserver/proxy/socks/Socks5ProxyHandler.java
+++ b/mockserver-netty/src/main/java/org/mockserver/proxy/socks/Socks5ProxyHandler.java
@@ -1,0 +1,94 @@
+package org.mockserver.proxy.socks;
+
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.socksx.v5.DefaultSocks5CommandResponse;
+import io.netty.handler.codec.socksx.v5.DefaultSocks5InitialResponse;
+import io.netty.handler.codec.socksx.v5.DefaultSocks5PasswordAuthResponse;
+import io.netty.handler.codec.socksx.v5.Socks5AddressType;
+import io.netty.handler.codec.socksx.v5.Socks5AuthMethod;
+import io.netty.handler.codec.socksx.v5.Socks5CommandRequest;
+import io.netty.handler.codec.socksx.v5.Socks5CommandRequestDecoder;
+import io.netty.handler.codec.socksx.v5.Socks5CommandStatus;
+import io.netty.handler.codec.socksx.v5.Socks5CommandType;
+import io.netty.handler.codec.socksx.v5.Socks5InitialRequest;
+import io.netty.handler.codec.socksx.v5.Socks5InitialRequestDecoder;
+import io.netty.handler.codec.socksx.v5.Socks5Message;
+import io.netty.handler.codec.socksx.v5.Socks5PasswordAuthRequest;
+import io.netty.handler.codec.socksx.v5.Socks5PasswordAuthRequestDecoder;
+import io.netty.handler.codec.socksx.v5.Socks5PasswordAuthStatus;
+import org.mockserver.configuration.ConfigurationProperties;
+import org.mockserver.lifecycle.LifeCycle;
+import org.mockserver.logging.MockServerLogger;
+
+@ChannelHandler.Sharable
+public class Socks5ProxyHandler extends SocksProxyHandler<Socks5Message> {
+
+    public Socks5ProxyHandler(LifeCycle server, MockServerLogger mockServerLogger) {
+        super(server, mockServerLogger);
+    }
+
+    @Override
+    protected void channelRead0(final ChannelHandlerContext ctx, Socks5Message socksRequest) {
+        if (socksRequest instanceof Socks5InitialRequest) {
+            handleInitialRequest(ctx, (Socks5InitialRequest) socksRequest);
+        } else if (socksRequest instanceof Socks5PasswordAuthRequest) {
+            handlePasswordAuthRequest(ctx, (Socks5PasswordAuthRequest) socksRequest);
+        } else if (socksRequest instanceof Socks5CommandRequest) {
+            handleCommandRequest(ctx, (Socks5CommandRequest) socksRequest);
+        } else {
+            ctx.close();
+        }
+    }
+
+    private void handleInitialRequest(ChannelHandlerContext ctx, Socks5InitialRequest initialRequest) {
+        String username = ConfigurationProperties.socksProxyServerUsername();
+        String password = ConfigurationProperties.socksProxyServerPassword();
+        Socks5AuthMethod requiredAuthMethod;
+        ChannelHandler nextRequestDecoder;
+        if (!username.isEmpty() && !password.isEmpty()) {
+            requiredAuthMethod = Socks5AuthMethod.PASSWORD;
+            nextRequestDecoder = new Socks5PasswordAuthRequestDecoder();
+        } else {
+            requiredAuthMethod = Socks5AuthMethod.NO_AUTH;
+            nextRequestDecoder = new Socks5CommandRequestDecoder();
+        }
+        answerInitialRequest(ctx, initialRequest, requiredAuthMethod, nextRequestDecoder);
+    }
+
+    private void answerInitialRequest(ChannelHandlerContext ctx, Socks5InitialRequest initialRequest, Socks5AuthMethod requiredAuthMethod, ChannelHandler nextRequestDecoder) {
+        ctx.pipeline().remove(Socks5InitialRequestDecoder.class);
+        for (Socks5AuthMethod authMethod : initialRequest.authMethods()) {
+            if (requiredAuthMethod.equals(authMethod)) {
+                ctx.pipeline().addFirst(nextRequestDecoder);
+                ctx.write(new DefaultSocks5InitialResponse(requiredAuthMethod));
+                return;
+            }
+        }
+        ctx.write(new DefaultSocks5InitialResponse(Socks5AuthMethod.UNACCEPTED));
+    }
+
+    private void handlePasswordAuthRequest(ChannelHandlerContext ctx, Socks5PasswordAuthRequest passwordAuthRequest) {
+        String username = ConfigurationProperties.socksProxyServerUsername();
+        String password = ConfigurationProperties.socksProxyServerPassword();
+        // we need the null-check again here, in case the properties got unset between init and auth request
+        if (!username.isEmpty() && !password.isEmpty()
+            && username.equals(passwordAuthRequest.username()) && password.equals(passwordAuthRequest.password())) {
+
+            ctx.pipeline().replace(Socks5PasswordAuthRequestDecoder.class, null, new Socks5CommandRequestDecoder());
+            ctx.write(new DefaultSocks5PasswordAuthResponse(Socks5PasswordAuthStatus.SUCCESS));
+        } else {
+            ctx.writeAndFlush(new DefaultSocks5PasswordAuthResponse(Socks5PasswordAuthStatus.FAILURE)).addListener(ChannelFutureListener.CLOSE);
+        }
+    }
+
+    private void handleCommandRequest(ChannelHandlerContext ctx, final Socks5CommandRequest commandRequest) {
+        if (commandRequest.type().equals(Socks5CommandType.CONNECT)) {
+            forwardConnection(ctx, new Socks5ConnectHandler(server, mockServerLogger, commandRequest.dstAddr(), commandRequest.dstPort()), commandRequest.dstAddr(), commandRequest.dstPort());
+            ctx.fireChannelRead(commandRequest);
+        } else {
+            ctx.writeAndFlush(new DefaultSocks5CommandResponse(Socks5CommandStatus.COMMAND_UNSUPPORTED, Socks5AddressType.DOMAIN, "", 0)).addListener(ChannelFutureListener.CLOSE);
+        }
+    }
+}

--- a/mockserver-netty/src/main/java/org/mockserver/proxy/socks/SocksConnectHandler.java
+++ b/mockserver-netty/src/main/java/org/mockserver/proxy/socks/SocksConnectHandler.java
@@ -6,14 +6,17 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.HttpContentDecompressor;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
-import io.netty.handler.codec.socks.*;
+import io.netty.handler.codec.socksx.v4.DefaultSocks4CommandResponse;
+import io.netty.handler.codec.socksx.v4.Socks4CommandRequest;
+import io.netty.handler.codec.socksx.v4.Socks4CommandStatus;
+import io.netty.handler.codec.socksx.v4.Socks4ServerEncoder;
 import io.netty.handler.ssl.SslHandler;
 import org.mockserver.lifecycle.LifeCycle;
 import org.mockserver.logging.MockServerLogger;
 import org.mockserver.proxy.relay.RelayConnectHandler;
 
 @ChannelHandler.Sharable
-public final class SocksConnectHandler extends RelayConnectHandler<SocksCmdRequest> {
+public abstract class SocksConnectHandler<T> extends RelayConnectHandler<T> {
 
     public SocksConnectHandler(LifeCycle server, MockServerLogger mockServerLogger, String host, int port) {
         super(server, mockServerLogger, host, port);
@@ -25,23 +28,6 @@ public final class SocksConnectHandler extends RelayConnectHandler<SocksCmdReque
         removeHandler(pipeline, HttpServerCodec.class);
         removeHandler(pipeline, HttpContentDecompressor.class);
         removeHandler(pipeline, HttpObjectAggregator.class);
-        removeHandler(pipeline, SocksMessageEncoder.class);
         removeHandler(pipeline, this);
-    }
-
-    protected Object successResponse(Object request) {
-        if (request != null && request instanceof SocksCmdRequest) {
-            return new SocksCmdResponse(SocksCmdStatus.SUCCESS, ((SocksCmdRequest) request).addressType(), ((SocksCmdRequest) request).host(), ((SocksCmdRequest) request).port());
-        } else {
-            return new SocksCmdResponse(SocksCmdStatus.SUCCESS, SocksAddressType.UNKNOWN);
-        }
-    }
-
-    protected Object failureResponse(Object request) {
-        if (request != null && request instanceof SocksCmdRequest) {
-            return new SocksCmdResponse(SocksCmdStatus.FAILURE, ((SocksCmdRequest) request).addressType(), ((SocksCmdRequest) request).host(), ((SocksCmdRequest) request).port());
-        } else {
-            return new SocksCmdResponse(SocksCmdStatus.FAILURE, SocksAddressType.UNKNOWN);
-        }
     }
 }

--- a/mockserver-netty/src/main/java/org/mockserver/proxy/socks/SocksDetector.java
+++ b/mockserver-netty/src/main/java/org/mockserver/proxy/socks/SocksDetector.java
@@ -1,0 +1,120 @@
+package org.mockserver.proxy.socks;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.ReplayingDecoder;
+import io.netty.handler.codec.socksx.SocksVersion;
+import io.netty.handler.codec.socksx.v4.Socks4CommandType;
+import io.netty.handler.codec.socksx.v5.Socks5AuthMethod;
+
+import static io.netty.handler.codec.socksx.v5.Socks5AuthMethod.GSSAPI;
+import static io.netty.handler.codec.socksx.v5.Socks5AuthMethod.NO_AUTH;
+import static io.netty.handler.codec.socksx.v5.Socks5AuthMethod.PASSWORD;
+
+/**
+ * This class is expected to be used from within a {@link ReplayingDecoder}, or with enough bytes available.
+ * Readable bytes are not checked and so if not enough bytes are supplied, index exceptions will arise.
+ */
+public class SocksDetector {
+
+    private SocksDetector() {
+        throw new UnsupportedOperationException();
+    }
+
+    public static boolean isSocks4(ByteBuf msg, int actualReadableBytes) {
+        // first byte has to be 4
+        int i = msg.readerIndex();
+        if (SocksVersion.valueOf(msg.getByte(i++)) != SocksVersion.SOCKS4a) {
+            return false;
+        }
+
+        // second byte has to be 1 or 2
+        Socks4CommandType commandType = Socks4CommandType.valueOf(msg.getByte(i++));
+        if (!(commandType.equals(Socks4CommandType.CONNECT) || commandType.equals(Socks4CommandType.BIND))) {
+            return false;
+        }
+
+        if (-1 == (i = consumeFields(msg, i + 2))) {
+            return false;
+        }
+
+        // end of available bytes reached
+        // if not, it is probably not SOCKS4
+        // do this check last so that any waiting for data is already done
+        return i == actualReadableBytes;
+    }
+
+    private static int consumeFields(ByteBuf msg, int i) {
+        boolean socks4a = msg.getByte(i++) == 0 &&
+            msg.getByte(i) == 0 &&
+            msg.getByte(i + 1) == 0 &&
+            msg.getByte(i + 2) != 0;
+
+        if (-1 == (i = consumeUsername(msg, i + 3))) {
+            return -1;
+        }
+
+        if (socks4a) {
+            if (-1 == (i = consumeHostname(msg, i))) {
+                return -1;
+            }
+        }
+
+        return i;
+    }
+
+    private static int consumeUsername(ByteBuf msg, int i) {
+        // consume the username (maximum 256 characters to not wait for the 0 endlessly if none comes)
+        int j = i + 256;
+        while ((i < j) && (msg.getByte(i) != 0)) {
+            i++;
+        }
+
+        // hostname was not 0-terminated
+        if (i == j) {
+            return -1;
+        }
+
+        return i + 1;
+    }
+
+    private static int consumeHostname(ByteBuf msg, int i) {
+        // empty hostname
+        if (msg.getByte(i) == 0) {
+            return -1;
+        }
+
+        // consume the remaining hostname (maximum 256 characters to not wait for the 0 endlessly if none comes)
+        int j = i + 256;
+        while ((++i < j) && (msg.getByte(i) != 0)) {
+        }
+
+        // hostname was not 0-terminated
+        if (i == j) {
+            return -1;
+        }
+
+        return i + 1;
+    }
+
+    public static boolean isSocks5(ByteBuf msg, int actualReadableBytes) {
+        // first byte has to be 5
+        if (SocksVersion.valueOf(msg.getByte(msg.readerIndex())) != SocksVersion.SOCKS5) {
+            return false;
+        }
+
+        // then the amount of authentication methods
+        byte numberOfAuthenticationMethods = msg.getByte(msg.readerIndex() + 1);
+
+        // now the authentication methods
+        for (int i = 0; i < numberOfAuthenticationMethods; i++) {
+            Socks5AuthMethod authMethod = Socks5AuthMethod.valueOf(msg.getByte(msg.readerIndex() + 2 + i));
+            if (!(NO_AUTH.equals(authMethod) || PASSWORD.equals(authMethod) || GSSAPI.equals(authMethod))) {
+                return false;
+            }
+        }
+
+        // more methods than advertised, either broken request or not actually SOCKS5
+        // do this check last so that any waiting for data is already done
+        return actualReadableBytes == (2 + numberOfAuthenticationMethods);
+    }
+}

--- a/mockserver-netty/src/test/java/org/mockserver/integration/proxy/socks/NettyHttpProxySOCKSIntegrationTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/integration/proxy/socks/NettyHttpProxySOCKSIntegrationTest.java
@@ -36,8 +36,13 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeThat;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.socket.SSLSocketFactory.sslSocketFactory;
 import static org.mockserver.test.Assert.assertContains;
@@ -95,6 +100,12 @@ public class NettyHttpProxySOCKSIntegrationTest {
 
     @Test
     public void shouldProxyRequestsUsingHttpClientViaSOCKSConfiguredForJVM() throws Exception {
+        assumeThat("SOCKS5 is broken in JRE <9", System.getProperty("java.version"), not(anyOf(
+            startsWith("1.7."), equalTo("1.7"),
+            startsWith("7."), equalTo("7"),
+            startsWith("1.8."), equalTo("1.8"),
+            startsWith("8."), equalTo("8"))));
+
         ProxySelector defaultProxySelector = ProxySelector.getDefault();
         try {
             // given - SOCKS proxy JVM settings
@@ -135,6 +146,12 @@ public class NettyHttpProxySOCKSIntegrationTest {
 
     @Test
     public void shouldProxyRequestsUsingHttpClientViaSOCKSConfiguredForJVMToSecureServerPort() throws Exception {
+        assumeThat("SOCKS5 is broken in JRE <9", System.getProperty("java.version"), not(anyOf(
+            startsWith("1.7."), equalTo("1.7"),
+            startsWith("7."), equalTo("7"),
+            startsWith("1.8."), equalTo("1.8"),
+            startsWith("8."), equalTo("8"))));
+
         ProxySelector defaultProxySelector = ProxySelector.getDefault();
         try {
             // given - SOCKS proxy JVM settings
@@ -175,6 +192,12 @@ public class NettyHttpProxySOCKSIntegrationTest {
 
     @Test
     public void shouldProxyRequestsUsingHttpClientViaSOCKS() throws Exception {
+        assumeThat("SOCKS5 is broken in JRE <9", System.getProperty("java.version"), not(anyOf(
+            startsWith("1.7."), equalTo("1.7"),
+            startsWith("7."), equalTo("7"),
+            startsWith("1.8."), equalTo("1.8"),
+            startsWith("8."), equalTo("8"))));
+
         // given
         Registry<ConnectionSocketFactory> socketFactoryRegistry = RegistryBuilder.<ConnectionSocketFactory>create()
             .register("http", new ConnectionSocketFactory() {
@@ -247,6 +270,12 @@ public class NettyHttpProxySOCKSIntegrationTest {
 
     @Test
     public void shouldProxyRequestsUsingHttpClientViaSOCKSToSecureServerPort() throws Exception {
+        assumeThat("SOCKS5 is broken in JRE <9", System.getProperty("java.version"), not(anyOf(
+            startsWith("1.7."), equalTo("1.7"),
+            startsWith("7."), equalTo("7"),
+            startsWith("1.8."), equalTo("1.8"),
+            startsWith("8."), equalTo("8"))));
+
         // given
         Registry<ConnectionSocketFactory> reg = RegistryBuilder.<ConnectionSocketFactory>create()
             .register("https", new ConnectionSocketFactory() {
@@ -320,6 +349,12 @@ public class NettyHttpProxySOCKSIntegrationTest {
 
     @Test
     public void shouldProxyRequestsUsingRawSecureSocketViaSOCKSToSecureServerPort() throws Exception {
+        assumeThat("SOCKS5 is broken in JRE <9", System.getProperty("java.version"), not(anyOf(
+            startsWith("1.7."), equalTo("1.7"),
+            startsWith("7."), equalTo("7"),
+            startsWith("1.8."), equalTo("1.8"),
+            startsWith("8."), equalTo("8"))));
+
         proxyRequestsUsingRawSocketViaSOCKS(true);
     }
 

--- a/mockserver-netty/src/test/java/org/mockserver/proxy/direct/DirectProxyUnificationHandlerTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/proxy/direct/DirectProxyUnificationHandlerTest.java
@@ -16,7 +16,7 @@ import org.mockserver.lifecycle.LifeCycle;
 import org.mockserver.logging.MockServerLogger;
 import org.mockserver.mock.HttpStateHandler;
 import org.mockserver.mockserver.MockServerUnificationInitializer;
-import org.mockserver.proxy.socks.SocksProxyHandler;
+import org.mockserver.proxy.socks.Socks5ProxyHandler;
 import org.mockserver.scheduler.Scheduler;
 import org.mockserver.unification.PortUnificationHandler;
 
@@ -54,13 +54,13 @@ public class DirectProxyUnificationHandlerTest {
             assertThat(String.valueOf(embeddedChannel.pipeline().names()), embeddedChannel.pipeline().names(), contains(
                 "SslHandler#0",
                 "LoggingHandler#0",
-                "MockServerUnificationInitializer#0",
+                "MockServerUnificationInitializerDelegate#0",
                 "DefaultChannelPipeline$TailContext#0"
             ));
         } else {
             assertThat(String.valueOf(embeddedChannel.pipeline().names()), embeddedChannel.pipeline().names(), contains(
                 "SslHandler#0",
-                "MockServerUnificationInitializer#0",
+                "MockServerUnificationInitializerDelegate#0",
                 "DefaultChannelPipeline$TailContext#0"
             ));
         }
@@ -74,7 +74,7 @@ public class DirectProxyUnificationHandlerTest {
 //        embeddedChannel.attr(HTTP_CONNECT_SOCKET).set(new InetSocketAddress(localPort));
 
         // and - no SOCKS handlers
-        assertThat(embeddedChannel.pipeline().get(SocksProxyHandler.class), is(nullValue()));
+        assertThat(embeddedChannel.pipeline().get(Socks5ProxyHandler.class), is(nullValue()));
         assertThat(embeddedChannel.pipeline().get(SocksMessageEncoder.class), is(nullValue()));
         assertThat(embeddedChannel.pipeline().get(SocksInitRequestDecoder.class), is(nullValue()));
 
@@ -97,18 +97,18 @@ public class DirectProxyUnificationHandlerTest {
         if (new MockServerLogger().isEnabled(TRACE)) {
             assertThat(String.valueOf(embeddedChannel.pipeline().names()), embeddedChannel.pipeline().names(), contains(
                 "LoggingHandler#0",
-                "SocksCmdRequestDecoder#0",
-                "SocksMessageEncoder#0",
-                "SocksProxyHandler#0",
-                "MockServerUnificationInitializer#0",
+                "Socks5CommandRequestDecoder#0",
+                "Socks5ServerEncoder#0",
+                "Socks5ProxyHandler#0",
+                "MockServerUnificationInitializerDelegate#0",
                 "DefaultChannelPipeline$TailContext#0"
             ));
         } else {
             assertThat(String.valueOf(embeddedChannel.pipeline().names()), embeddedChannel.pipeline().names(), contains(
-                "SocksCmdRequestDecoder#0",
-                "SocksMessageEncoder#0",
-                "SocksProxyHandler#0",
-                "MockServerUnificationInitializer#0",
+                "Socks5CommandRequestDecoder#0",
+                "Socks5ServerEncoder#0",
+                "Socks5ProxyHandler#0",
+                "MockServerUnificationInitializerDelegate#0",
                 "DefaultChannelPipeline$TailContext#0"
             ));
         }

--- a/mockserver-netty/src/test/java/org/mockserver/proxy/http/HttpProxyUnificationInitializerTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/proxy/http/HttpProxyUnificationInitializerTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 import org.mockserver.lifecycle.LifeCycle;
 import org.mockserver.mock.HttpStateHandler;
 import org.mockserver.mockserver.MockServerUnificationInitializer;
-import org.mockserver.proxy.socks.SocksProxyHandler;
+import org.mockserver.proxy.socks.Socks5ProxyHandler;
 import org.mockserver.scheduler.Scheduler;
 
 import java.io.IOException;
@@ -49,7 +49,7 @@ public class HttpProxyUnificationInitializerTest {
         // then - should add SSL handlers first
         assertThat(String.valueOf(embeddedChannel.pipeline().names()), embeddedChannel.pipeline().names(), contains(
             "SslHandler#0",
-            "MockServerUnificationInitializer#0",
+            "MockServerUnificationInitializerDelegate#0",
             "DefaultChannelPipeline$TailContext#0"
         ));
     }
@@ -62,7 +62,7 @@ public class HttpProxyUnificationInitializerTest {
 //        embeddedChannel.attr(HTTP_CONNECT_SOCKET).set(new InetSocketAddress(localPort));
 
         // and - no SOCKS handlers
-        assertThat(embeddedChannel.pipeline().get(SocksProxyHandler.class), is(nullValue()));
+        assertThat(embeddedChannel.pipeline().get(Socks5ProxyHandler.class), is(nullValue()));
         assertThat(embeddedChannel.pipeline().get(SocksMessageEncoder.class), is(nullValue()));
         assertThat(embeddedChannel.pipeline().get(SocksInitRequestDecoder.class), is(nullValue()));
 
@@ -83,10 +83,10 @@ public class HttpProxyUnificationInitializerTest {
 
         // and then - should add SOCKS handlers first
         assertThat(String.valueOf(embeddedChannel.pipeline().names()), embeddedChannel.pipeline().names(), contains(
-            "SocksCmdRequestDecoder#0",
-            "SocksMessageEncoder#0",
-            "SocksProxyHandler#0",
-            "MockServerUnificationInitializer#0",
+            "Socks5CommandRequestDecoder#0",
+            "Socks5ServerEncoder#0",
+            "Socks5ProxyHandler#0",
+            "MockServerUnificationInitializerDelegate#0",
             "DefaultChannelPipeline$TailContext#0"
         ));
     }

--- a/mockserver-netty/src/test/java/org/mockserver/proxy/socks/SocksDetectorTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/proxy/socks/SocksDetectorTest.java
@@ -1,0 +1,340 @@
+package org.mockserver.proxy.socks;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SocksDetectorTest {
+
+    @Test
+    public void successfullyParseSocks4ConnectRequest() {
+        ByteBuf msg = Unpooled.wrappedBuffer(new byte[]{
+            0x04, // protocol version
+            0x01, // command code
+            0x00, 0x00, // port
+            0x06, 0x06, 0x06, 0x06,  // ip
+            'f', 'o', 'o', 0x00 // username
+        });
+        assertTrue(SocksDetector.isSocks4(msg, msg.readableBytes()));
+    }
+
+    @Test
+    public void successfullyParseSocks4BindRequest() {
+        ByteBuf msg = Unpooled.wrappedBuffer(new byte[]{
+            0x04, // protocol version
+            0x02, // command code
+            0x00, 0x00, // port
+            0x06, 0x06, 0x06, 0x06,  // ip
+            'f', 'o', 'o', 0x00 // username
+        });
+        assertTrue(SocksDetector.isSocks4(msg, msg.readableBytes()));
+    }
+
+    @Test
+    public void successfullyParseSocks4RequestWithEmptyUsername() {
+        ByteBuf msg = Unpooled.wrappedBuffer(new byte[]{
+            0x04, // protocol version
+            0x01, // command code
+            0x00, 0x00, // port
+            0x06, 0x06, 0x06, 0x06,  // ip
+            0x00 // username
+        });
+        assertTrue(SocksDetector.isSocks4(msg, msg.readableBytes()));
+    }
+
+    @Test
+    public void successfullyParseSocks4RequestWithMaxLengthUsername() {
+        ByteBuf msg = Unpooled.wrappedBuffer(new byte[]{
+            0x04, // protocol version
+            0x01, // command code
+            0x00, 0x00, // port
+            0x06, 0x06, 0x06, 0x06,  // ip
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', // username
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', 0x00
+        });
+        assertTrue(SocksDetector.isSocks4(msg, msg.readableBytes()));
+    }
+
+    @Test
+    public void failParsingSocks4RequestWithWrongProtocolVersion() {
+        ByteBuf msg = Unpooled.wrappedBuffer(new byte[]{
+            0x05, // protocol version
+            0x01, // command code
+            0x00, 0x00, // port
+            0x06, 0x06, 0x06, 0x06,  // ip
+            'f', 'o', 'o', 0x00 // username
+        });
+        assertFalse(SocksDetector.isSocks4(msg, msg.readableBytes()));
+    }
+
+    @Test
+    public void failParsingSocks4RequestWithUnsupportedCommandCode() {
+        ByteBuf msg = Unpooled.wrappedBuffer(new byte[]{
+            0x04, // protocol version
+            0x03, // command code
+            0x00, 0x00, // port
+            0x06, 0x06, 0x06, 0x06,  // ip
+            'f', 'o', 'o', 0x00 // username
+        });
+        assertFalse(SocksDetector.isSocks4(msg, msg.readableBytes()));
+    }
+
+    @Test
+    public void failParsingSocks4RequestWithTooLongUsername() {
+        ByteBuf msg = Unpooled.wrappedBuffer(new byte[]{
+            0x04, // protocol version
+            0x01, // command code
+            0x00, 0x00, // port
+            0x06, 0x06, 0x06, 0x06,  // ip
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', // username
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', 0x00
+        });
+        assertFalse(SocksDetector.isSocks4(msg, msg.readableBytes()));
+    }
+
+    @Test
+    public void failParsingSocks4RequestWithAdditionalReadableBytes() {
+        ByteBuf msg = Unpooled.wrappedBuffer(new byte[]{
+            0x04, // protocol version
+            0x01, // command code
+            0x00, 0x00, // port
+            0x06, 0x06, 0x06, 0x06,  // ip
+            'f', 'o', 'o', 0x00, // username
+            0x00 // additional byte
+        });
+        assertFalse(SocksDetector.isSocks4(msg, msg.readableBytes()));
+    }
+
+    @Test
+    public void successfullyParseSocks4aRequest() {
+        ByteBuf msg = Unpooled.wrappedBuffer(new byte[]{
+            0x04, // protocol version
+            0x01, // command code
+            0x00, 0x00, // port
+            0x00, 0x00, 0x00, 0x06,  // invalid ip
+            'f', 'o', 'o', 0x00, // username
+            'f', 'o', 'o', 0x00 // hostname
+        });
+        assertTrue(SocksDetector.isSocks4(msg, msg.readableBytes()));
+    }
+
+    @Test
+    public void successfullyParseSocks4aRequestWithEmptyUsername() {
+        ByteBuf msg = Unpooled.wrappedBuffer(new byte[]{
+            0x04, // protocol version
+            0x01, // command code
+            0x00, 0x00, // port
+            0x00, 0x00, 0x00, 0x06,  // invalid ip
+            0x00, // username
+            'f', 'o', 'o', 0x00 // hostname
+        });
+        assertTrue(SocksDetector.isSocks4(msg, msg.readableBytes()));
+    }
+
+    @Test
+    public void successfullyParseSocks4aRequestWithMaxLengthHostname() {
+        ByteBuf msg = Unpooled.wrappedBuffer(new byte[]{
+            0x04, // protocol version
+            0x01, // command code
+            0x00, 0x00, // port
+            0x00, 0x00, 0x00, 0x06,  // invalid ip
+            'f', 'o', 'o', 0x00, // username
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', // hostname
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', 0x00
+        });
+        assertTrue(SocksDetector.isSocks4(msg, msg.readableBytes()));
+    }
+
+    @Test
+    public void failParsingSocks4aRequestWithTooLongHostname() {
+        ByteBuf msg = Unpooled.wrappedBuffer(new byte[]{
+            0x04, // protocol version
+            0x01, // command code
+            0x00, 0x00, // port
+            0x00, 0x00, 0x00, 0x06,  // invalid ip
+            'f', 'o', 'o', 0x00, // username
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', // hostname
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+            '1', '2', '3', '4', '5', '6', 0x00
+        });
+        assertFalse(SocksDetector.isSocks4(msg, msg.readableBytes()));
+    }
+
+    @Test
+    public void failParsingSocks4aRequestWithEmptyHostname() {
+        ByteBuf msg = Unpooled.wrappedBuffer(new byte[]{
+            0x04, // protocol version
+            0x01, // command code
+            0x00, 0x00, // port
+            0x00, 0x00, 0x00, 0x06,  // invalid ip
+            'f', 'o', 'o', 0x00, // username
+            0x00 // hostname
+        });
+        assertFalse(SocksDetector.isSocks4(msg, msg.readableBytes()));
+    }
+
+    @Test
+    public void failParsingSocks4aRequestWithAdditionalReadableBytes() {
+        ByteBuf msg = Unpooled.wrappedBuffer(new byte[]{
+            0x04, // protocol version
+            0x01, // command code
+            0x00, 0x00, // port
+            0x00, 0x00, 0x00, 0x06,  // invalid ip
+            'f', 'o', 'o', 0x00, // username
+            'f', 'o', 'o', 0x00, // hostname
+            0x00 // additional byte
+        });
+        assertFalse(SocksDetector.isSocks4(msg, msg.readableBytes()));
+    }
+
+    @Test
+    public void successfullyParseSocks5Request() {
+        ByteBuf msg = Unpooled.wrappedBuffer(new byte[]{
+            0x05, // protocol version
+            0x02, // amount of authentication methods
+            0x00, 0x02 // authentication methods
+        });
+        assertTrue(SocksDetector.isSocks5(msg, msg.readableBytes()));
+    }
+
+    @Test
+    public void successfullyParseSocks5RequestWithManyMethods() {
+        ByteBuf msg = Unpooled.wrappedBuffer(new byte[]{
+            0x05, // protocol version
+            0x05, // amount of authentication methods
+            0x00, 0x01, 0x02, 0x00, 0x01 // authentication methods
+        });
+        assertTrue(SocksDetector.isSocks5(msg, msg.readableBytes()));
+    }
+
+    @Test
+    public void failParsingSocks5RequestWithWrongProtocolVersion() {
+        ByteBuf msg = Unpooled.wrappedBuffer(new byte[]{
+            0x04, // protocol version
+            0x05, // amount of authentication methods
+            0x00, 0x01, 0x02, 0x00, 0x01 // authentication methods
+        });
+        assertFalse(SocksDetector.isSocks5(msg, msg.readableBytes()));
+    }
+
+    @Test
+    public void failParsingSocks5RequestWithUnsupportedAuthenticationMethod() {
+        ByteBuf msg = Unpooled.wrappedBuffer(new byte[]{
+            0x05, // protocol version
+            0x01, // amount of authentication methods
+            0x05 // authentication methods
+        });
+        assertFalse(SocksDetector.isSocks5(msg, msg.readableBytes()));
+    }
+
+    @Test
+    public void failParsingSocks5RequestWithAdditionalReadableBytes() {
+        ByteBuf msg = Unpooled.wrappedBuffer(new byte[]{
+            0x05, // protocol version
+            0x01, // amount of authentication methods
+            0x00, // authentication methods
+            0x00 // additional byte
+        });
+        assertFalse(SocksDetector.isSocks5(msg, msg.readableBytes()));
+    }
+}


### PR DESCRIPTION
- when acting as SOCKS5 proxy, provide the ability to require username / password authentication (#529)
- use a replaying decoder for the protocol detection to get as many bytes as needed (#531)
- support SOCKS4 and SOCKS4a instead of only SOCKS5 (#528)
- only select auth methods the client offered in the SOCKS5 initial response (#529)
- detect SOCKS protocols before SSL, as valid SOCKS messages can be recognized as SSL messages erroneously
- do not try to decode the amount of SOCKS5 auth schemes as auth scheme which will fail if there are more than 2 auth methods available
- do not treat SOCKS4, SOCKS4a and SOCKS5 equally when determining protocol, as their messages are quite different (#528)



Please thoroughly review this, I never did any netty stuff before and just learned what I did while doing it, so I might have made mistakes.