### PR TITLE
Don't run Docker container as root

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,5 +25,11 @@ WORKDIR /opt/mockserver
 # expose ports.
 EXPOSE 1080 1090
 
+# don't run MockServer as root
+RUN addgroup -g 1000 mockserver && \
+    adduser -H -D -u 1000 -G mockserver mockserver
+RUN chown -R mockserver:mockserver /opt/mockserver
+USER mockserver
+
 # define default command.
 CMD ["/opt/mockserver/run_mockserver.sh", "-logLevel", "INFO", "-serverPort", "1080"]


### PR DESCRIPTION
Some people don't like having their containers running as root user, especially in context of k8s deployments. This patch will create and use the user 'mockserver' with UID 1000 instead.