### PR TITLE
Add support of complex patterns matching in regex

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/matchers/RegexStringMatcher.java
+++ b/mockserver-core/src/main/java/org/mockserver/matchers/RegexStringMatcher.java
@@ -6,6 +6,7 @@ import org.mockserver.logging.MockServerLogger;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.NottableString;
 
+import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import static org.mockserver.logging.MockServerLogger.MOCK_SERVER_LOGGER;
@@ -82,6 +83,16 @@ public class RegexStringMatcher extends BodyMatcher<NottableString> {
                         MOCK_SERVER_LOGGER.trace("Error while matching regex [" + matched.toLowerCase() + "] for string [" + matcher.toLowerCase() + "] " + pse.getMessage());
                     }
                 }
+                // add support of complex patterns
+                if (!result) {
+                    try {
+                        Pattern p = Pattern.compile(matcher);
+                        result = p.matcher(matched).matches();
+                    } catch (PatternSyntaxException pse) {
+                        MOCK_SERVER_LOGGER.trace("Error while matching regex [" + matcher.toLowerCase() + "] for string [" + matched.toLowerCase() + "] " + pse.getMessage());
+                    }
+                }
+
             }
         }
 

--- a/mockserver-core/src/test/java/org/mockserver/matchers/RegexStringMatcherTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/matchers/RegexStringMatcherTest.java
@@ -120,4 +120,18 @@ public class RegexStringMatcherTest {
     public void shouldHandleIllegalRegexPatternForTest() {
         assertFalse(new RegexStringMatcher(new MockServerLogger(), "some_value").matches("/{}"));
     }
+
+    @Test
+    public void shouldHandleRegexPatternFlagsTest() {
+        assertTrue(new RegexStringMatcher(new MockServerLogger(), "(?ms).*some_value.*")
+            .matches("some_string\nsome_value\nanother_string"));
+    }
+
+    @Test
+    public void shouldHandleRegexPatternFlagsIgnoreCaseTest() {
+        assertTrue(new RegexStringMatcher(new MockServerLogger(), "(?i)^some_value")
+            .matches("Some_value"));
+    }
+
+
 }


### PR DESCRIPTION
Add support of multiline regex matching, for instance multiline.
e.g. 
    "(?ms).*some_value.* 
will match multiline string 
   """some_string
        some_value
        another_string"""

it's required for instance with body matching functionality when body contains \n  