### PR TITLE
Corrected Host header - no port necessary

### DIFF
--- a/mockserver-client-java/src/main/java/org/mockserver/client/MockServerClient.java
+++ b/mockserver-client-java/src/main/java/org/mockserver/client/MockServerClient.java
@@ -156,7 +156,7 @@ public class MockServerClient implements Stoppable {
             }
 
             HttpResponse response = nettyHttpClient.sendRequest(
-                request.withHeader(HOST.toString(), this.host + ":" + port()),
+                request.withHeader(HOST.toString(), this.host),
                 ConfigurationProperties.maxSocketTimeout(),
                 TimeUnit.MILLISECONDS
             );


### PR DESCRIPTION
Because of incorrect Host header returned response status is 404.