### PR TITLE
Fix memory leak in DashboardWebSocketServerHandler (#618)

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/ui/MockServerEventLogNotifier.java
+++ b/mockserver-core/src/main/java/org/mockserver/ui/MockServerEventLogNotifier.java
@@ -35,4 +35,8 @@ public class MockServerEventLogNotifier extends ObjectWithReflectiveEqualsHashCo
     public void registerListener(MockServerLogListener listener) {
         listeners.add(listener);
     }
+
+    public void unregisterListener(MockServerLogListener listener) {
+        listeners.remove(listener);
+    }
 }

--- a/mockserver-core/src/main/java/org/mockserver/ui/MockServerMatcherNotifier.java
+++ b/mockserver-core/src/main/java/org/mockserver/ui/MockServerMatcherNotifier.java
@@ -35,4 +35,8 @@ public class MockServerMatcherNotifier extends ObjectWithReflectiveEqualsHashCod
     public void registerListener(MockServerMatcherListener listener) {
         listeners.add(listener);
     }
+
+    public void unregisterListener(MockServerMatcherListener listener) {
+        listeners.remove(listener);
+    }
 }

--- a/mockserver-netty/src/main/java/org/mockserver/dashboard/DashboardWebSocketServerHandler.java
+++ b/mockserver-netty/src/main/java/org/mockserver/dashboard/DashboardWebSocketServerHandler.java
@@ -152,6 +152,13 @@ public class DashboardWebSocketServerHandler extends ChannelInboundHandlerAdapte
     }
 
     @Override
+    public void channelInactive(ChannelHandlerContext ctx) {
+        mockServerMatcher.unregisterListener(this);
+        mockServerLog.unregisterListener(this);
+        ctx.fireChannelInactive();
+    }
+
+    @Override
     public void updated(MockServerEventLog mockServerLog) {
         for (Map.Entry<ChannelHandlerContext, HttpRequest> registryEntry : clientRegistry.entrySet()) {
             sendUpdate(registryEntry.getValue(), registryEntry.getKey());


### PR DESCRIPTION
Motivation:
Instances of DashboardWebSocketServerHandler are not removed from listeners list even if appropriate channels are closed which causes a memory leak.

Modification:
Unsubscribe the handler on channel close.

Fixes #618 