### PR TITLE
ssl: generates 2048 RSA key

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/socket/tls/KeyAndCertificateFactory.java
+++ b/mockserver-core/src/main/java/org/mockserver/socket/tls/KeyAndCertificateFactory.java
@@ -50,11 +50,10 @@ public class KeyAndCertificateFactory {
      */
     private static final int ROOT_KEYSIZE = 2048;
     /**
-     * Generates an 1024 bit RSA key pair using SHA1PRNG for the server
-     * certificates. Thoughts: 2048 takes much longer time on older CPUs. And
-     * for almost every client, 1024 is sufficient.
+     * Generates an 2048 bit RSA key pair using SHA1PRNG for the server
+     * certificates.
      */
-    private static final int FAKE_KEYSIZE = 1024;
+    private static final int FAKE_KEYSIZE = 2048;
     /**
      * Current time minus 1 year, just in case software clock goes back due to
      * time synchronization


### PR DESCRIPTION
Openssl 1.1.1 does not considere 1024bit RSA key as secure.

So this patch changes the generated key size to 2048

Closes: #661