### PR TITLE
added basic support for access-control-request-headers

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/cors/CORSHeaders.java
+++ b/mockserver-core/src/main/java/org/mockserver/cors/CORSHeaders.java
@@ -34,9 +34,13 @@ public class CORSHeaders {
             setHeaderIfNotAlreadyExists(response, HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), ANY_ORIGIN);
         }
         setHeaderIfNotAlreadyExists(response, HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString(), "CONNECT, DELETE, GET, HEAD, OPTIONS, POST, PUT, PATCH, TRACE");
-        String headers = "Allow, Content-Encoding, Content-Length, Content-Type, ETag, Expires, Last-Modified, Location, Server, Vary, Authorization";
-        setHeaderIfNotAlreadyExists(response, HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS.toString(), headers);
-        setHeaderIfNotAlreadyExists(response, HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS.toString(), headers);
+        String defaultHeaders = "Allow, Content-Encoding, Content-Length, Content-Type, ETag, Expires, Last-Modified, Location, Server, Vary, Authorization";
+        String allowHeaders = defaultHeaders;
+        if (!request.getFirstHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS.toString()).isEmpty()) {
+            allowHeaders += ", " + request.getFirstHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS.toString());
+        }
+        setHeaderIfNotAlreadyExists(response, HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS.toString(), allowHeaders);
+        setHeaderIfNotAlreadyExists(response, HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS.toString(), defaultHeaders);
         setHeaderIfNotAlreadyExists(response, HttpHeaderNames.ACCESS_CONTROL_MAX_AGE.toString(), "300");
         if (!enableCORSForAPIHasBeenSetExplicitly()) {
             setHeaderIfNotAlreadyExists(response, "x-cors", "MockServer CORS support enabled by default, to disable ConfigurationProperties.enableCORSForAPI(false) or -Dmockserver.enableCORSForAPI=false");

--- a/mockserver-core/src/test/java/org/mockserver/cors/CORSHeadersTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/cors/CORSHeadersTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockserver.cors.CORSHeaders.isPreflightRequest;
@@ -117,6 +118,21 @@ public class CORSHeadersTest {
         assertThat(response.getFirstHeader("access-control-expose-headers"), is("Allow, Content-Encoding, Content-Length, Content-Type, ETag, Expires, Last-Modified, Location, Server, Vary, Authorization"));
         assertThat(response.getFirstHeader("access-control-max-age"), is("300"));
         assertThat(response.getFirstHeader("x-cors"), is("MockServer CORS support enabled by default, to disable ConfigurationProperties.enableCORSForAPI(false) or -Dmockserver.enableCORSForAPI=false"));
+    }
+
+    @Test
+    public void shouldAddCORSHeaderForExtraRequestHeaders() {
+        // given
+        HttpRequest request = request()
+            .withMethod("OPTIONS")
+            .withHeader("Access-Control-Request-Headers", "X-API-Key");
+        HttpResponse response = response();
+
+        // when
+        new CORSHeaders().addCORSHeaders(request, response);
+
+        // then
+        assertThat(response.getFirstHeader("access-control-allow-headers"), containsString("X-API-Key"));
     }
 
 }


### PR DESCRIPTION
A CORS preflight request can include the Access-Control-Request-Headers header
to tell the server which headers that will be sent by the client. The headers
mentioned should be added to the response header Access-Control-Allow-Headers
to tell the client that this is fine, otherwise the preflight will fail.